### PR TITLE
Add rendering timing statistics

### DIFF
--- a/lib/rayz/camera.rb
+++ b/lib/rayz/camera.rb
@@ -57,6 +57,7 @@ module Rayz
     def render(world)
       image = Canvas.new(width: @hsize, height: @vsize)
 
+      start_time = Time.now
       puts "Progress (each dot = 10 rows):"
       (0...@vsize).each do |y|
         print "." if y % 10 == 0
@@ -68,7 +69,14 @@ module Rayz
           image.write_pixel(row: @vsize - 1 - y, col: x, color: color)
         end
       end
+      end_time = Time.now
+
+      total_time = end_time - start_time
+      time_per_row = total_time / @vsize
+
       puts "\nDone!"
+      puts "Rendering took #{total_time.round(2)} seconds"
+      puts "Time per row: #{(time_per_row * 1000).round(2)} ms"
 
       image
     end

--- a/lib/rayz/chapter5.rb
+++ b/lib/rayz/chapter5.rb
@@ -106,6 +106,8 @@ module Rayz
       # Color
       red = Rayz::Color.new(red: 1.0, green: 0.0, blue: 0.0)
 
+      start_time = Time.now
+
       # For each pixel on the canvas
       canvas_pixels.times do |y|
         # Convert canvas y to world y
@@ -132,6 +134,13 @@ module Rayz
           end
         end
       end
+
+      end_time = Time.now
+      total_time = end_time - start_time
+      time_per_row = total_time / canvas_pixels
+
+      puts "Rendering took #{total_time.round(2)} seconds"
+      puts "Time per row: #{(time_per_row * 1000).round(2)} ms"
 
       file_name = "chapter5_sphere.ppm"
       print "Writing sphere silhouette to #{file_name}..."

--- a/lib/rayz/chapter6.rb
+++ b/lib/rayz/chapter6.rb
@@ -49,6 +49,8 @@ module Rayz
       puts "Light position: #{light_position}"
       puts "Progress (each dot = 10 rows):"
 
+      start_time = Time.now
+
       # For each row of pixels in the canvas
       (0...canvas_pixels).each do |y|
         # Compute the world y coordinate (top = +half, bottom = -half)
@@ -94,7 +96,13 @@ module Rayz
         end
       end
 
+      end_time = Time.now
+      total_time = end_time - start_time
+      time_per_row = total_time / canvas_pixels
+
       puts "\nDone!"
+      puts "Rendering took #{total_time.round(2)} seconds"
+      puts "Time per row: #{(time_per_row * 1000).round(2)} ms"
 
       # Save to PPM file
       puts "Writing to chapter6.ppm..."


### PR DESCRIPTION
## Summary
- Added rendering time tracking to all chapters that generate images (5, 6, 7)
- Displays total rendering time in seconds
- Displays average time per row in milliseconds
- Helps track rendering performance as the ray tracer evolves

## Test plan
- [x] Ran `ruby rayz` and verified all chapters show timing output
- [x] Chapter 5: ~2.83 seconds, ~14ms per row (200x200 pixels)
- [x] Chapter 6: ~30.27 seconds, ~76ms per row (400x400 pixels)
- [x] Chapter 7: ~84.68 seconds, ~423ms per row (400x200 pixels with shadows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)