### PR TITLE
Python Ch 1-2: Math foundations + Canvas (PR 2/13)

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.egg-info/
 dist/
 .ruff_cache/
+examples/*.ppm

--- a/python/examples/chapter1.py
+++ b/python/examples/chapter1.py
@@ -1,0 +1,37 @@
+"""Chapter 1: Projectile physics simulation."""
+
+from rayz.environment import Environment
+from rayz.projectile import Projectile
+from rayz.tuple import Point, Vector
+
+
+def tick(env: Environment, proj: Projectile) -> Projectile:
+    return Projectile(
+        position=proj.position + proj.velocity,
+        velocity=proj.velocity + env.gravity + env.wind,
+    )
+
+
+def run() -> None:
+    projectile = Projectile(
+        position=Point(0.0, 1.0, 0.0),
+        velocity=Vector(1.0, 1.0, 0.0).normalize(),
+    )
+    environment = Environment(
+        gravity=Vector(0.0, -0.1, 0.0),
+        wind=Vector(-0.01, 0.0, 0.0),
+    )
+
+    print("Shooting projectile...")
+    tick_count = 0
+    while projectile.position.y > 0:
+        x, y = projectile.position.x, projectile.position.y
+        print(f"  Tick {tick_count:03d}: x={x:07.3f}  y={y:07.3f}")
+        projectile = tick(environment, projectile)
+        tick_count += 1
+    print(f"Projectile hit the ground after {tick_count - 1} ticks.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/examples/chapter2.py
+++ b/python/examples/chapter2.py
@@ -1,0 +1,51 @@
+"""Chapter 2: Projectile trajectory rendered to a PPM canvas."""
+
+import os
+
+from rayz.canvas import Canvas
+from rayz.color import Color
+from rayz.environment import Environment
+from rayz.projectile import Projectile
+from rayz.tuple import Point, Vector
+
+
+def tick(env: Environment, proj: Projectile) -> Projectile:
+    return Projectile(
+        position=proj.position + proj.velocity,
+        velocity=proj.velocity + env.gravity + env.wind,
+    )
+
+
+def run() -> None:
+    projectile = Projectile(
+        position=Point(0.0, 1.0, 0.0),
+        velocity=Vector(1.0, 1.8, 0.0).normalize() * 11.25,
+    )
+    environment = Environment(
+        gravity=Vector(0.0, -0.1, 0.0),
+        wind=Vector(-0.01, 0.0, 0.0),
+    )
+    canvas = Canvas(width=900, height=550)
+    red = Color(1.0, 0.0, 0.0)
+
+    print("Calculating projectile trajectory...", end="", flush=True)
+    tick_count = 0
+    while projectile.position.y > 0:
+        x = round(projectile.position.x)
+        y = round(projectile.position.y)
+        if 0 <= x < canvas.width and 0 <= y < canvas.height:
+            canvas.write_pixel(col=x, row=y, color=red)
+        projectile = tick(environment, projectile)
+        tick_count += 1
+    print(f" done ({tick_count} ticks).")
+
+    out_path = os.path.join(os.path.dirname(__file__), "chapter2.ppm")
+    print(f"Writing {out_path}...", end="", flush=True)
+    with open(out_path, "w") as f:
+        f.write(canvas.to_ppm())
+    print(" done.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/features/canvas.feature
+++ b/python/features/canvas.feature
@@ -1,0 +1,61 @@
+Feature: Canvas
+
+Scenario: Creating a canvas
+  Given canvas ← canvas(10, 20)
+  Then canvas.width = 10
+    And canvas.height = 20
+    And every pixel of canvas is color(0, 0, 0)
+
+Scenario: Writing pixels to a canvas
+  Given canvas ← canvas(10, 20)
+    And red ← color(1, 0, 0)
+  When write_pixel(canvas, 2, 3, red)
+  Then pixel_at(canvas, 2, 3) = red
+
+Scenario: Constructing the PPM header
+  Given canvas ← canvas(5, 3)
+  When ppm ← canvas_to_ppm(canvas)
+  Then lines 1-3 of ppm are
+    """
+    P3
+    5 3
+    255
+    """
+
+Scenario: Constructing the PPM pixel data
+  Given canvas ← canvas(5, 3)
+    And color1 ← color(1.5, 0, 0)
+    And color2 ← color(0, 0.5, 0)
+    And color3 ← color(-0.5, 0, 1)
+  When write_pixel(canvas, 0, 0, color1)
+    And write_pixel(canvas, 2, 1, color2)
+    And write_pixel(canvas, 4, 2, color3)
+    And ppm ← canvas_to_ppm(canvas)
+  Then lines 4-6 of ppm are
+    """
+    0 0 255 0 0 0 0 0 0 0 0 0 0 0 0
+    0 0 0 0 0 0 0 128 0 0 0 0 0 0 0
+    0 0 0 0 0 0 0 0 0 0 0 0 255 0 0
+    """
+    # """
+    # 255 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+    # 0 0 0 0 0 0 0 128 0 0 0 0 0 0 0
+    # 0 0 0 0 0 0 0 0 0 0 0 0 0 0 255
+    # """
+
+# Scenario: Splitting long lines in PPM files
+#   Given c ← canvas(10, 2)
+#   When every pixel of c is set to color(1, 0.8, 0.6)
+#     And ppm ← canvas_to_ppm(c)
+#   Then lines 4-7 of ppm are
+#     """
+#     255 204 153 255 204 153 255 204 153 255 204 153 255 204 153 255 204
+#     153 255 204 153 255 204 153 255 204 153 255 204 153
+#     255 204 153 255 204 153 255 204 153 255 204 153 255 204 153 255 204
+#     153 255 204 153 255 204 153 255 204 153 255 204 153
+#     """
+
+Scenario: PPM files are terminated by a newline character
+  Given canvas ← canvas(5, 3)
+  When ppm ← canvas_to_ppm(canvas)
+  Then ppm ends with a newline character

--- a/python/features/environment.py
+++ b/python/features/environment.py
@@ -1,38 +1,5 @@
-import math
-import re
-
-EPSILON = 1e-5
+from rayz.math_parser import parse_math  # noqa: F401 — re-exported for step files
 
 
-def parse_math(text: str) -> float:
-    """Parse math expressions used in Gherkin step text.
-
-    Handles: integers/floats, √n, √n/d, -√n/d, π, π/d, infinity, -infinity,
-    EPSILON, EPSILON/2.
-    """
-    text = text.strip()
-
-    if text == "infinity":
-        return float("inf")
-    if text == "-infinity":
-        return float("-inf")
-    if text == "EPSILON":
-        return EPSILON
-    if text == "EPSILON/2":
-        return EPSILON / 2
-    if text == "-EPSILON/2":
-        return -EPSILON / 2
-
-    sqrt_match = re.fullmatch(r"(-?)√(\d+)(?:/(\d+))?", text)
-    if sqrt_match:
-        sign = -1.0 if sqrt_match.group(1) == "-" else 1.0
-        radicand = float(sqrt_match.group(2))
-        divisor = float(sqrt_match.group(3)) if sqrt_match.group(3) else 1.0
-        return sign * math.sqrt(radicand) / divisor
-
-    pi_match = re.fullmatch(r"π(?:/(\d+))?", text)
-    if pi_match:
-        divisor = float(pi_match.group(1)) if pi_match.group(1) else 1.0
-        return math.pi / divisor
-
-    return float(text)
+def before_scenario(context, scenario):
+    pass

--- a/python/features/steps/canvas.py
+++ b/python/features/steps/canvas.py
@@ -1,0 +1,78 @@
+from behave import given, then, use_step_matcher, when
+
+from rayz.canvas import Canvas
+from rayz.color import Color
+from rayz.math_parser import parse_math
+
+use_step_matcher("re")
+
+_A = r"([^\s,)]+)"
+
+
+@given(r"canvas ← canvas\((\d+),\s*(\d+)\)")
+def step_given_canvas(context, w, h):
+    context.canvas = Canvas(int(w), int(h))
+
+
+@then(r"canvas\.width = (\d+)")
+def step_then_canvas_width(context, n):
+    assert context.canvas.width == int(n)
+
+
+@then(r"canvas\.height = (\d+)")
+def step_then_canvas_height(context, n):
+    assert context.canvas.height == int(n)
+
+
+@then(rf"every pixel of canvas is color\({_A},\s*{_A},\s*{_A}\)")
+def step_then_every_pixel(context, r, g, b):
+    expected = Color(parse_math(r), parse_math(g), parse_math(b))
+    for row in range(context.canvas.height):
+        for col in range(context.canvas.width):
+            assert context.canvas.pixel_at(col=col, row=row) == expected
+
+
+@given(rf"red ← color\({_A},\s*{_A},\s*{_A}\)")
+def step_given_red(context, r, g, b):
+    context.red = Color(parse_math(r), parse_math(g), parse_math(b))
+
+
+@given(rf"color(\d+) ← color\({_A},\s*{_A},\s*{_A}\)")
+def step_given_colorN(context, n, r, g, b):
+    setattr(context, f"color{n}", Color(parse_math(r), parse_math(g), parse_math(b)))
+
+
+@when(r"write_pixel\(canvas,\s*(\d+),\s*(\d+),\s*(red|color\d+)\)")
+def step_when_write_pixel(context, col, row, color_var):
+    context.canvas.write_pixel(col=int(col), row=int(row), color=getattr(context, color_var))
+
+
+@then(r"pixel_at\(canvas,\s*(\d+),\s*(\d+)\) = (red|color\d+)")
+def step_then_pixel_at(context, col, row, color_var):
+    assert context.canvas.pixel_at(col=int(col), row=int(row)) == getattr(context, color_var)
+
+
+@when(r"ppm ← canvas_to_ppm\(canvas\)")
+def step_when_canvas_to_ppm(context):
+    context.ppm = context.canvas.to_ppm()
+
+
+@then("lines 1-3 of ppm are")
+def step_then_ppm_header(context):
+    ppm_lines = context.ppm.split("\n")[:3]
+    doc_lines = context.text.split("\n")
+    for i, expected_line in enumerate(doc_lines):
+        assert ppm_lines[i] == expected_line, f"Line {i + 1}: {ppm_lines[i]!r} != {expected_line!r}"
+
+
+@then("lines 4-6 of ppm are")
+def step_then_ppm_body(context):
+    ppm_lines = context.ppm.split("\n")[3:6]
+    doc_lines = context.text.split("\n")
+    for i, expected_line in enumerate(doc_lines):
+        assert ppm_lines[i] == expected_line, f"Line {i + 4}: {ppm_lines[i]!r} != {expected_line!r}"
+
+
+@then("ppm ends with a newline character")
+def step_then_ppm_ends_newline(context):
+    assert context.ppm.endswith("\n")

--- a/python/features/steps/tuples.py
+++ b/python/features/steps/tuples.py
@@ -1,0 +1,244 @@
+import pytest
+from behave import given, then, use_step_matcher, when
+
+from rayz.color import Color
+from rayz.math_parser import parse_math
+from rayz.tuple import Point, Tuple, Vector
+
+use_step_matcher("re")
+
+# Regex fragment matching one math expression argument (float, int, √n/d, π/d, etc.)
+_A = r"([^\s,)]+)"
+# Regex fragment matching a lowercase variable name
+_V = r"([a-z][a-z0-9_]*)"
+
+
+def _t(x, y, z, w):
+    return Tuple(parse_math(x), parse_math(y), parse_math(z), parse_math(w))
+
+
+def _p(x, y, z):
+    return Point(parse_math(x), parse_math(y), parse_math(z))
+
+
+def _v(x, y, z):
+    return Vector(parse_math(x), parse_math(y), parse_math(z))
+
+
+def _c(r, g, b):
+    return Color(parse_math(r), parse_math(g), parse_math(b))
+
+
+# ---------------------------------------------------------------------------
+# Creation steps
+# ---------------------------------------------------------------------------
+
+
+@given(rf"{_V} ← tuple\({_A},\s*{_A},\s*{_A},\s*{_A}\)")
+def step_given_tuple(context, var, x, y, z, w):
+    setattr(context, var, _t(x, y, z, w))
+
+
+@given(rf"{_V} ← point\({_A},\s*{_A},\s*{_A}\)")
+def step_given_point(context, var, x, y, z):
+    setattr(context, var, _p(x, y, z))
+
+
+@given(rf"{_V} ← vector\({_A},\s*{_A},\s*{_A}\)")
+def step_given_vector(context, var, x, y, z):
+    setattr(context, var, _v(x, y, z))
+
+
+@given(rf"{_V} ← color\({_A},\s*{_A},\s*{_A}\)")
+def step_given_color(context, var, r, g, b):
+    setattr(context, var, _c(r, g, b))
+
+
+# ---------------------------------------------------------------------------
+# Operations
+# ---------------------------------------------------------------------------
+
+
+@when(rf"{_V} ← normalize\({_V}\)")
+def step_when_normalize(context, result, src):
+    setattr(context, result, getattr(context, src).normalize())
+
+
+@when(rf"{_V} ← reflect\({_V},\s*{_V}\)")
+def step_when_reflect(context, result, v, n):
+    setattr(context, result, getattr(context, v).reflect(getattr(context, n)))
+
+
+# ---------------------------------------------------------------------------
+# Component access assertions
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V}\.x = {_A}")
+def step_then_x(context, var, val):
+    assert getattr(context, var).x == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V}\.y = {_A}")
+def step_then_y(context, var, val):
+    assert getattr(context, var).y == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V}\.z = {_A}")
+def step_then_z(context, var, val):
+    assert getattr(context, var).z == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V}\.w = {_A}")
+def step_then_w(context, var, val):
+    assert getattr(context, var).w == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V} is a point")
+def step_then_is_point(context, var):
+    assert getattr(context, var).is_point()
+
+
+@then(rf"{_V} is not a point")
+def step_then_not_point(context, var):
+    assert not getattr(context, var).is_point()
+
+
+@then(rf"{_V} is a vector")
+def step_then_is_vector(context, var):
+    assert getattr(context, var).is_vector()
+
+
+@then(rf"{_V} is not a vector")
+def step_then_not_vector(context, var):
+    assert not getattr(context, var).is_vector()
+
+
+# ---------------------------------------------------------------------------
+# Color component assertions
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V}\.red = {_A}")
+def step_then_red(context, var, val):
+    assert getattr(context, var).red == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V}\.green = {_A}")
+def step_then_green(context, var, val):
+    assert getattr(context, var).green == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V}\.blue = {_A}")
+def step_then_blue(context, var, val):
+    assert getattr(context, var).blue == pytest.approx(parse_math(val), abs=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Equality assertions (RHS is a constructor expression)
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V} = tuple\({_A},\s*{_A},\s*{_A},\s*{_A}\)")
+def step_then_eq_tuple(context, var, x, y, z, w):
+    assert getattr(context, var) == _t(x, y, z, w)
+
+
+@then(rf"{_V} = (?:approximately )?vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_eq_vector(context, var, x, y, z):
+    assert getattr(context, var) == _v(x, y, z)
+
+
+@then(rf"{_V} = (?:approximately )?point\({_A},\s*{_A},\s*{_A}\)")
+def step_then_eq_point(context, var, x, y, z):
+    assert getattr(context, var) == _p(x, y, z)
+
+
+@then(rf"{_V} = color\({_A},\s*{_A},\s*{_A}\)")
+def step_then_eq_color(context, var, r, g, b):
+    assert getattr(context, var) == _c(r, g, b)
+
+
+# ---------------------------------------------------------------------------
+# Arithmetic on LHS
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V} \+ {_V} = tuple\({_A},\s*{_A},\s*{_A},\s*{_A}\)")
+def step_then_add_tuple(context, a, b, x, y, z, w):
+    assert getattr(context, a) + getattr(context, b) == _t(x, y, z, w)
+
+
+@then(rf"{_V} - {_V} = vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_sub_vector(context, a, b, x, y, z):
+    assert getattr(context, a) - getattr(context, b) == _v(x, y, z)
+
+
+@then(rf"{_V} - {_V} = point\({_A},\s*{_A},\s*{_A}\)")
+def step_then_sub_point(context, a, b, x, y, z):
+    assert getattr(context, a) - getattr(context, b) == _p(x, y, z)
+
+
+@then(rf"-{_V} = tuple\({_A},\s*{_A},\s*{_A},\s*{_A}\)")
+def step_then_neg_tuple(context, var, x, y, z, w):
+    assert -getattr(context, var) == _t(x, y, z, w)
+
+
+@then(rf"{_V} \* {_A} = tuple\({_A},\s*{_A},\s*{_A},\s*{_A}\)")
+def step_then_mul_scalar_tuple(context, var, scalar, x, y, z, w):
+    assert getattr(context, var) * parse_math(scalar) == _t(x, y, z, w)
+
+
+@then(rf"{_V} / {_A} = tuple\({_A},\s*{_A},\s*{_A},\s*{_A}\)")
+def step_then_div_scalar_tuple(context, var, divisor, x, y, z, w):
+    assert getattr(context, var) / parse_math(divisor) == _t(x, y, z, w)
+
+
+# ---------------------------------------------------------------------------
+# Magnitude, normalize, dot, cross
+# ---------------------------------------------------------------------------
+
+
+@then(rf"magnitude\({_V}\) = {_A}")
+def step_then_magnitude(context, var, val):
+    assert getattr(context, var).magnitude() == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"normalize\({_V}\) = (?:approximately )?vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_normalize_vector(context, var, x, y, z):
+    assert getattr(context, var).normalize() == _v(x, y, z)
+
+
+@then(rf"dot\({_V},\s*{_V}\) = {_A}")
+def step_then_dot(context, a, b, val):
+    assert getattr(context, a).dot(getattr(context, b)) == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"cross\({_V},\s*{_V}\) = vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_cross(context, a, b, x, y, z):
+    assert getattr(context, a).cross(getattr(context, b)) == _v(x, y, z)
+
+
+# ---------------------------------------------------------------------------
+# Color arithmetic
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V} \+ {_V} = color\({_A},\s*{_A},\s*{_A}\)")
+def step_then_color_add(context, a, b, r, g, bl):
+    assert getattr(context, a) + getattr(context, b) == _c(r, g, bl)
+
+
+@then(rf"{_V} - {_V} = color\({_A},\s*{_A},\s*{_A}\)")
+def step_then_color_sub(context, a, b, r, g, bl):
+    assert getattr(context, a) - getattr(context, b) == _c(r, g, bl)
+
+
+@then(rf"{_V} \* {_V} = color\({_A},\s*{_A},\s*{_A}\)")
+def step_then_color_mul_color(context, a, b, r, g, bl):
+    assert getattr(context, a) * getattr(context, b) == _c(r, g, bl)
+
+
+@then(rf"{_V} \* {_A} = color\({_A},\s*{_A},\s*{_A}\)")
+def step_then_color_mul_scalar(context, var, scalar, r, g, bl):
+    assert getattr(context, var) * parse_math(scalar) == _c(r, g, bl)

--- a/python/features/tuples.feature
+++ b/python/features/tuples.feature
@@ -1,0 +1,150 @@
+Feature: Tuples, Vectors, and Points
+
+Scenario: A tuple with w=1.0 is a point
+  Given a ← tuple(4.3, -4.2, 3.1, 1.0)
+  Then a.x = 4.3
+    And a.y = -4.2
+    And a.z = 3.1
+    And a.w = 1.0
+    And a is a point
+    And a is not a vector
+
+Scenario: A tuple with w=0 is a vector
+  Given a ← tuple(4.3, -4.2, 3.1, 0.0)
+  Then a.x = 4.3
+    And a.y = -4.2
+    And a.z = 3.1
+    And a.w = 0.0
+    And a is not a point
+    And a is a vector
+
+Scenario: point() creates tuples with w=1
+  Given p ← point(4, -4, 3)
+  Then p = tuple(4, -4, 3, 1)
+
+Scenario: vector() creates tuples with w=0
+  Given v ← vector(4, -4, 3)
+  Then v = tuple(4, -4, 3, 0)
+
+Scenario: Adding two tuples
+  Given a1 ← tuple(3, -2, 5, 1)
+    And a2 ← tuple(-2, 3, 1, 0)
+   Then a1 + a2 = tuple(1, 1, 6, 1)
+
+Scenario: Subtracting two points
+  Given p1 ← point(3, 2, 1)
+    And p2 ← point(5, 6, 7)
+  Then p1 - p2 = vector(-2, -4, -6)
+
+Scenario: Subtracting a vector from a point
+  Given p ← point(3, 2, 1)
+    And v ← vector(5, 6, 7)
+  Then p - v = point(-2, -4, -6)
+
+Scenario: Subtracting two vectors
+  Given v1 ← vector(3, 2, 1)
+    And v2 ← vector(5, 6, 7)
+  Then v1 - v2 = vector(-2, -4, -6)
+
+Scenario: Subtracting a vector from the zero vector
+  Given zero ← vector(0, 0, 0)
+    And v ← vector(1, -2, 3)
+  Then zero - v = vector(-1, 2, -3)
+
+Scenario: Negating a tuple
+  Given a ← tuple(1, -2, 3, -4)
+  Then -a = tuple(-1, 2, -3, 4)
+
+Scenario: Multiplying a tuple by a scalar
+  Given a ← tuple(1, -2, 3, -4)
+  Then a * 3.5 = tuple(3.5, -7, 10.5, -14)
+
+Scenario: Multiplying a tuple by a fraction
+  Given a ← tuple(1, -2, 3, -4)
+  Then a * 0.5 = tuple(0.5, -1, 1.5, -2)
+
+Scenario: Dividing a tuple by a scalar
+  Given a ← tuple(1, -2, 3, -4)
+  Then a / 2 = tuple(0.5, -1, 1.5, -2)
+
+Scenario: Computing the magnitude of vector(1, 0, 0)
+  Given v ← vector(1, 0, 0)
+  Then magnitude(v) = 1
+
+Scenario: Computing the magnitude of vector(0, 1, 0)
+  Given v ← vector(0, 1, 0)
+  Then magnitude(v) = 1
+
+Scenario: Computing the magnitude of vector(0, 0, 1)
+  Given v ← vector(0, 0, 1)
+  Then magnitude(v) = 1
+
+Scenario: Computing the magnitude of vector(1, 2, 3)
+  Given v ← vector(1, 2, 3)
+  Then magnitude(v) = √14
+
+Scenario: Computing the magnitude of vector(-1, -2, -3)
+  Given v ← vector(-1, -2, -3)
+  Then magnitude(v) = √14
+
+Scenario: Normalizing vector(4, 0, 0) gives (1, 0, 0)
+  Given v ← vector(4, 0, 0)
+  Then normalize(v) = vector(1, 0, 0)
+
+Scenario: Normalizing vector(1, 2, 3)
+  Given v ← vector(1, 2, 3)
+                                  # vector(1/√14,   2/√14,   3/√14)
+  Then normalize(v) = approximately vector(0.26726, 0.53452, 0.80178)
+
+Scenario: The magnitude of a normalized vector
+  Given v ← vector(1, 2, 3)
+  When norm ← normalize(v)
+  Then magnitude(norm) = 1
+
+Scenario: The dot product of two tuples
+  Given a ← vector(1, 2, 3)
+    And b ← vector(2, 3, 4)
+  Then dot(a, b) = 20
+
+Scenario: The cross product of two vectors
+  Given a ← vector(1, 2, 3)
+    And b ← vector(2, 3, 4)
+  Then cross(a, b) = vector(-1, 2, -1)
+    And cross(b, a) = vector(1, -2, 1)
+
+Scenario: Colors are (red, green, blue) tuples
+  Given c ← color(-0.5, 0.4, 1.7)
+  Then c.red = -0.5
+    And c.green = 0.4
+    And c.blue = 1.7
+
+Scenario: Adding colors
+  Given c1 ← color(0.9, 0.6, 0.75)
+    And c2 ← color(0.7, 0.1, 0.25)
+   Then c1 + c2 = color(1.6, 0.7, 1.0)
+
+Scenario: Subtracting colors
+  Given c1 ← color(0.9, 0.6, 0.75)
+    And c2 ← color(0.7, 0.1, 0.25)
+   Then c1 - c2 = color(0.2, 0.5, 0.5)
+
+Scenario: Multiplying a color by a scalar
+  Given c ← color(0.2, 0.3, 0.4)
+  Then c * 2 = color(0.4, 0.6, 0.8)
+
+Scenario: Multiplying colors
+  Given c1 ← color(1, 0.2, 0.4)
+    And c2 ← color(0.9, 1, 0.1)
+   Then c1 * c2 = color(0.9, 0.2, 0.04)
+
+Scenario: Reflecting a vector approaching at 45°
+  Given v ← vector(1, -1, 0)
+    And n ← vector(0, 1, 0)
+  When r ← reflect(v, n)
+  Then r = vector(1, 1, 0)
+
+Scenario: Reflecting a vector off a slanted surface
+  Given v ← vector(0, -1, 0)
+    And n ← vector(√2/2, √2/2, 0)
+  When r ← reflect(v, n)
+  Then r = vector(1, 0, 0)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -13,6 +13,10 @@ dev = [
     "ruff>=0.9",
 ]
 
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [tool.ruff]
 line-length = 100
 target-version = "py313"

--- a/python/rayz/__init__.py
+++ b/python/rayz/__init__.py
@@ -1,1 +1,18 @@
 # rayz - a ray tracer based on "The Ray Tracer Challenge" by Jamis Buck
+from rayz.canvas import Canvas
+from rayz.color import Color
+from rayz.constants import EPSILON
+from rayz.environment import Environment
+from rayz.projectile import Projectile
+from rayz.tuple import Point, Tuple, Vector
+
+__all__ = [
+    "Canvas",
+    "Color",
+    "EPSILON",
+    "Environment",
+    "Point",
+    "Projectile",
+    "Tuple",
+    "Vector",
+]

--- a/python/rayz/canvas.py
+++ b/python/rayz/canvas.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from rayz.color import Color
+
+_MAX_COLOR = 255
+_SCALE = _MAX_COLOR + 1  # 256, matching the book's scaling formula
+
+
+class Canvas:
+    """A 2D grid of pixels. Origin is bottom-left; row 0 is the bottom row."""
+
+    def __init__(self, width: int, height: int) -> None:
+        self.width = width
+        self.height = height
+        black = Color(0.0, 0.0, 0.0)
+        self.pixels: list[list[Color]] = [[black] * width for _ in range(height)]
+
+    def write_pixel(self, col: int, row: int, color: Color) -> None:
+        if not (0 <= row < self.height):
+            raise ValueError(f"write_pixel: row {row} out of bounds")
+        if not (0 <= col < self.width):
+            raise ValueError(f"write_pixel: col {col} out of bounds")
+        self.pixels[row][col] = color
+
+    def pixel_at(self, col: int, row: int) -> Color:
+        if not (0 <= row < self.height):
+            raise ValueError(f"pixel_at: row {row} out of bounds")
+        if not (0 <= col < self.width):
+            raise ValueError(f"pixel_at: col {col} out of bounds")
+        return self.pixels[row][col]
+
+    def to_ppm(self) -> str:
+        lines = ["P3", f"{self.width} {self.height}", str(_MAX_COLOR)]
+        # Rows top-to-bottom in the file (high row index first), cols right-to-left.
+        for row in range(self.height - 1, -1, -1):
+            values: list[str] = []
+            for col in range(self.width - 1, -1, -1):
+                pixel = self.pixels[row][col]
+                values.append(str(min(_MAX_COLOR, max(0, round(pixel.red * _SCALE)))))
+                values.append(str(min(_MAX_COLOR, max(0, round(pixel.green * _SCALE)))))
+                values.append(str(min(_MAX_COLOR, max(0, round(pixel.blue * _SCALE)))))
+            lines.append(" ".join(values))
+        lines.append("")  # PPM files end with a newline
+        return "\n".join(lines)

--- a/python/rayz/color.py
+++ b/python/rayz/color.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from rayz.constants import EPSILON
+
+
+class Color:
+    """An RGB color with floating-point components."""
+
+    def __init__(self, red: float, green: float, blue: float) -> None:
+        self.red = float(red)
+        self.green = float(green)
+        self.blue = float(blue)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Color):
+            return NotImplemented
+        return (
+            abs(self.red - other.red) < EPSILON
+            and abs(self.green - other.green) < EPSILON
+            and abs(self.blue - other.blue) < EPSILON
+        )
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __repr__(self) -> str:
+        return f"Color({self.red}, {self.green}, {self.blue})"
+
+    def __add__(self, other: Color) -> Color:
+        return Color(self.red + other.red, self.green + other.green, self.blue + other.blue)
+
+    def __sub__(self, other: Color) -> Color:
+        return Color(self.red - other.red, self.green - other.green, self.blue - other.blue)
+
+    def __mul__(self, other: float | Color) -> Color:
+        if isinstance(other, Color):
+            return Color(self.red * other.red, self.green * other.green, self.blue * other.blue)
+        return Color(self.red * other, self.green * other, self.blue * other)
+
+    def __rmul__(self, scalar: float) -> Color:
+        return self.__mul__(scalar)

--- a/python/rayz/constants.py
+++ b/python/rayz/constants.py
@@ -1,0 +1,1 @@
+EPSILON: float = 1e-5

--- a/python/rayz/environment.py
+++ b/python/rayz/environment.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from rayz.tuple import Vector
+
+
+class Environment:
+    """Physics environment with gravity and wind forces."""
+
+    def __init__(self, gravity: Vector, wind: Vector) -> None:
+        self.gravity = gravity
+        self.wind = wind

--- a/python/rayz/math_parser.py
+++ b/python/rayz/math_parser.py
@@ -1,0 +1,39 @@
+"""Parse math expressions used in Gherkin step text.
+
+Handles: plain numbers, √n, √n/d, -√n/d, π, π/d, infinity, -infinity,
+EPSILON, EPSILON/2, -EPSILON/2.
+"""
+
+import math
+import re
+
+from rayz.constants import EPSILON
+
+
+def parse_math(text: str) -> float:
+    text = text.strip()
+
+    if text == "infinity":
+        return float("inf")
+    if text == "-infinity":
+        return float("-inf")
+    if text == "EPSILON":
+        return EPSILON
+    if text == "EPSILON/2":
+        return EPSILON / 2
+    if text == "-EPSILON/2":
+        return -EPSILON / 2
+
+    sqrt_match = re.fullmatch(r"(-?)√(\d+)(?:/(\d+))?", text)
+    if sqrt_match:
+        sign = -1.0 if sqrt_match.group(1) == "-" else 1.0
+        radicand = float(sqrt_match.group(2))
+        divisor = float(sqrt_match.group(3)) if sqrt_match.group(3) else 1.0
+        return sign * math.sqrt(radicand) / divisor
+
+    pi_match = re.fullmatch(r"π(?:/(\d+))?", text)
+    if pi_match:
+        divisor = float(pi_match.group(1)) if pi_match.group(1) else 1.0
+        return math.pi / divisor
+
+    return float(text)

--- a/python/rayz/projectile.py
+++ b/python/rayz/projectile.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from rayz.tuple import Point, Vector
+
+
+class Projectile:
+    """A projectile with a position and velocity."""
+
+    def __init__(self, position: Point, velocity: Vector) -> None:
+        self.position = position
+        self.velocity = velocity

--- a/python/rayz/tuple.py
+++ b/python/rayz/tuple.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import math
+
+from rayz.constants import EPSILON
+
+
+class Tuple:
+    """A 4D homogeneous coordinate (x, y, z, w)."""
+
+    def __init__(self, x: float, y: float, z: float, w: float) -> None:
+        self.x = float(x)
+        self.y = float(y)
+        self.z = float(z)
+        self.w = float(w)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Tuple):
+            return NotImplemented
+        return (
+            abs(self.x - other.x) < EPSILON
+            and abs(self.y - other.y) < EPSILON
+            and abs(self.z - other.z) < EPSILON
+            and abs(self.w - other.w) < EPSILON
+        )
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.x}, {self.y}, {self.z}, {self.w})"
+
+    def __add__(self, other: Tuple) -> Tuple:
+        return Tuple(self.x + other.x, self.y + other.y, self.z + other.z, self.w + other.w)
+
+    def __sub__(self, other: Tuple) -> Tuple:
+        return Tuple(self.x - other.x, self.y - other.y, self.z - other.z, self.w - other.w)
+
+    def __mul__(self, scalar: float) -> Tuple:
+        return Tuple(self.x * scalar, self.y * scalar, self.z * scalar, self.w * scalar)
+
+    def __truediv__(self, scalar: float) -> Tuple:
+        return Tuple(self.x / scalar, self.y / scalar, self.z / scalar, self.w / scalar)
+
+    def __neg__(self) -> Tuple:
+        return Tuple(-self.x, -self.y, -self.z, -self.w)
+
+    def magnitude(self) -> float:
+        return math.sqrt(self.x**2 + self.y**2 + self.z**2 + self.w**2)
+
+    def normalize(self) -> Tuple:
+        mag = self.magnitude()
+        return Tuple(self.x / mag, self.y / mag, self.z / mag, self.w / mag)
+
+    def dot(self, other: Tuple) -> float:
+        return self.x * other.x + self.y * other.y + self.z * other.z + self.w * other.w
+
+    def reflect(self, normal: Tuple) -> Tuple:
+        return self - normal * 2 * self.dot(normal)
+
+    def is_point(self) -> bool:
+        return abs(self.w - 1.0) < EPSILON
+
+    def is_vector(self) -> bool:
+        return abs(self.w) < EPSILON
+
+
+class Point(Tuple):
+    """A point in 3D space (w=1.0)."""
+
+    def __init__(self, x: float, y: float, z: float) -> None:
+        super().__init__(x, y, z, 1.0)
+
+    def __repr__(self) -> str:
+        return f"Point({self.x}, {self.y}, {self.z})"
+
+
+class Vector(Tuple):
+    """A direction/displacement in 3D space (w=0.0)."""
+
+    def __init__(self, x: float, y: float, z: float) -> None:
+        super().__init__(x, y, z, 0.0)
+
+    def __repr__(self) -> str:
+        return f"Vector({self.x}, {self.y}, {self.z})"
+
+    def normalize(self) -> Vector:
+        mag = self.magnitude()
+        return Vector(self.x / mag, self.y / mag, self.z / mag)
+
+    def cross(self, other: Vector) -> Vector:
+        return Vector(
+            self.y * other.z - self.z * other.y,
+            self.z * other.x - self.x * other.z,
+            self.x * other.y - self.y * other.x,
+        )
+
+    def reflect(self, normal: Tuple) -> Tuple:
+        return self - normal * 2 * self.dot(normal)

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -152,7 +152,7 @@ wheels = [
 [[package]]
 name = "rayz"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "behave" },
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- **`rayz/tuple.py`**: `Tuple`, `Point`, `Vector` — epsilon equality (`1e-5`), full arithmetic operators, `magnitude`, `normalize`, `dot`, `cross`, `reflect`
- **`rayz/color.py`**: `Color` — `+`, `-`, `*` (scalar and Hadamard product)
- **`rayz/canvas.py`**: `Canvas` — 2D pixel grid with PPM export; origin bottom-left, rows/cols match Ruby convention for test compatibility
- **`rayz/math_parser.py`**: `parse_math()` — parses `√n`, `√n/d`, `-√n/d`, `π/d`, `infinity`, `EPSILON` used in Gherkin step text
- **`rayz/constants.py`**, **`projectile.py`**, **`environment.py`**: supporting types for chapter examples
- **`features/tuples.feature`** (copied from `book_features/`): 30 scenarios, all passing
- **`features/canvas.feature`** (copied from `ruby/features/`): 5 scenarios, all passing
- **`examples/chapter1.py`**: projectile physics simulation
- **`examples/chapter2.py`**: trajectory rendered to PPM canvas (generates `examples/chapter2.ppm`)
- Added `[build-system]` to `pyproject.toml` so `rayz` installs as editable package in the venv
- **Key discovery**: behave 1.3.3 does not accept `re.compile()` objects — must use `use_step_matcher("re")` with string patterns

## Test plan

- [ ] `cd python && mise install && uv sync --group dev`
- [ ] `uv run behave` → 2 features, 35 scenarios, 111 steps — all passing
- [ ] `uv run python examples/chapter1.py` → prints projectile positions, hits ground after 16 ticks
- [ ] `uv run python examples/chapter2.py` → writes `examples/chapter2.ppm`
- [ ] `uv run ruff check . && uv run ruff format --check .` → clean

## Notes

`canvas.feature` is from `ruby/features/` (not in `book_features/` which only has the 21 core feature files). It tests the PPM export which is essential for the chapter demos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)