### PR TITLE
Add Python Ch 3: Matrix operations

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -1,0 +1,25 @@
+name: Lint (Python)
+
+on:
+  push:
+    paths:
+      - 'python/**'
+  pull_request:
+    paths:
+      - 'python/**'
+
+jobs:
+  ruff:
+    name: Ruff Linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.14"
+      - name: Run ruff
+        run: |
+          set -e
+          cd python
+          uv run ruff check .
+          uv run ruff format --check .

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,0 +1,22 @@
+name: Test (Python)
+
+on:
+  push:
+    paths:
+      - 'python/**'
+  pull_request:
+    paths:
+      - 'python/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.14"
+      - run: |
+          set -e
+          cd python
+          uv run behave features/

--- a/python/examples/chapter3.py
+++ b/python/examples/chapter3.py
@@ -69,12 +69,14 @@ def demo_clock_face() -> None:
         cos_a, sin_a = math.cos(angle), math.sin(angle)
 
         # Rotation in the XZ plane (Y-axis rotation), viewed from above
-        rotation = Matrix([
-            [cos_a,  0, sin_a, 0],
-            [0,      1, 0,     0],
-            [-sin_a, 0, cos_a, 0],
-            [0,      0, 0,     1],
-        ])
+        rotation = Matrix(
+            [
+                [cos_a, 0, sin_a, 0],
+                [0, 1, 0, 0],
+                [-sin_a, 0, cos_a, 0],
+                [0, 0, 0, 1],
+            ]
+        )
 
         twelve_oclock = Point(0, 0, radius)
         rotated = rotation * twelve_oclock

--- a/python/examples/chapter3.py
+++ b/python/examples/chapter3.py
@@ -1,0 +1,111 @@
+"""Chapter 3: Matrix operations — basic ops, inversion, and a clock-face visualization."""
+
+import math
+import os
+
+from rayz.canvas import Canvas
+from rayz.color import Color
+from rayz.matrix import Matrix
+from rayz.tuple import Point
+
+
+def _print_matrix(m: Matrix, rows: int = 4, cols: int = 4, precision: int = 2) -> None:
+    for r in range(rows):
+        values = [f"{m[r, c]:+{precision + 5}.{precision}f}" for c in range(cols)]
+        print(f"  [{' '.join(values)}]")
+
+
+def demo_basic_operations() -> None:
+    print("1. Basic Matrix Operations")
+    print("-" * 40)
+
+    m = Matrix([[1, 2, 3, 4], [5, 6, 7, 8], [9, 8, 7, 6], [5, 4, 3, 2]])
+    print("Matrix M:")
+    _print_matrix(m)
+
+    print("\nTranspose of M:")
+    _print_matrix(m.transpose())
+
+    print(f"\nDeterminant of M: {m.determinant():.2f}")
+
+    identity = Matrix.identity(4)
+    print(f"\nM * Identity == M: {m * identity == m}")
+    print()
+
+
+def demo_matrix_inversion() -> None:
+    print("\n2. Matrix Inversion")
+    print("-" * 40)
+
+    m = Matrix([[3, -9, 7, 3], [3, -8, 2, -9], [-4, 4, 4, 1], [-6, 5, -1, 1]])
+    print("Matrix A:")
+    _print_matrix(m)
+
+    print(f"\nDeterminant: {m.determinant():.2f}")
+    print(f"Is invertible: {m.is_invertible()}")
+
+    inv = m.inverse()
+    print("\nInverse of A:")
+    _print_matrix(inv, precision=5)
+
+    product = m * inv
+    print("\nA * inverse(A) ≈ Identity:")
+    _print_matrix(product, precision=5)
+    print()
+
+
+def demo_clock_face() -> None:
+    print("\n3. Clock Face Visualization")
+    print("-" * 40)
+    print("Drawing a clock using rotation matrices...")
+
+    canvas = Canvas(width=400, height=400)
+    white = Color(1.0, 1.0, 1.0)
+
+    center_x, center_y, radius = 200, 200, 150
+
+    for hour in range(12):
+        angle = hour * math.pi / 6.0
+        cos_a, sin_a = math.cos(angle), math.sin(angle)
+
+        # Rotation in the XZ plane (Y-axis rotation), viewed from above
+        rotation = Matrix([
+            [cos_a,  0, sin_a, 0],
+            [0,      1, 0,     0],
+            [-sin_a, 0, cos_a, 0],
+            [0,      0, 0,     1],
+        ])
+
+        twelve_oclock = Point(0, 0, radius)
+        rotated = rotation * twelve_oclock
+
+        # Map XZ to canvas XY; round to nearest pixel
+        canvas_x = center_x + round(rotated.x)
+        canvas_y = center_y + round(rotated.z)
+
+        # Draw a 5×5 dot for each hour mark
+        for dx in range(-2, 3):
+            for dy in range(-2, 3):
+                px, py = canvas_x + dx, canvas_y + dy
+                if 0 <= px < 400 and 0 <= py < 400:
+                    canvas.write_pixel(col=px, row=py, color=white)
+
+    out_path = os.path.join(os.path.dirname(__file__), "chapter3.ppm")
+    print(f"Writing {out_path}...", end="", flush=True)
+    with open(out_path, "w") as f:
+        f.write(canvas.to_ppm())
+    print(" done.")
+    print("Clock face with 12 hour marks drawn using rotation matrices.")
+    print("\n" + "=" * 60 + "\n")
+
+
+def run() -> None:
+    print("\n=== Chapter 3: Matrices ===")
+    print("Demonstrating matrix operations and transformations\n")
+    demo_basic_operations()
+    demo_matrix_inversion()
+    demo_clock_face()
+
+
+if __name__ == "__main__":
+    run()

--- a/python/examples/run.py
+++ b/python/examples/run.py
@@ -1,0 +1,46 @@
+"""Runner: execute chapter examples by number or run all.
+
+Usage (from python/):
+    uv run examples/run.py          # all chapters
+    uv run examples/run.py all      # all chapters (explicit)
+    uv run examples/run.py 1        # chapter 1 only
+    uv run examples/run.py 2 3      # chapters 2 and 3
+"""
+
+import sys
+
+from examples.chapter1 import run as ch1
+from examples.chapter2 import run as ch2
+from examples.chapter3 import run as ch3
+
+CHAPTERS: dict[int, tuple[str, object]] = {
+    1: ("Projectile physics", ch1),
+    2: ("Canvas & PPM export", ch2),
+    3: ("Matrices", ch3),
+}
+
+
+def main() -> None:
+    args = sys.argv[1:]
+
+    if not args or args == ["all"]:
+        targets = sorted(CHAPTERS.keys())
+    else:
+        targets = []
+        for a in args:
+            try:
+                targets.append(int(a))
+            except ValueError:
+                print(f"Unknown chapter: {a!r}  (valid: {sorted(CHAPTERS)})")
+                sys.exit(1)
+
+    for n in targets:
+        if n not in CHAPTERS:
+            print(f"Chapter {n} not yet implemented.")
+            continue
+        _name, fn = CHAPTERS[n]
+        fn()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/features/matrices.feature
+++ b/python/features/matrices.feature
@@ -1,0 +1,254 @@
+Feature: Matrices
+
+Scenario: Constructing and inspecting a 4x4 matrix
+  Given the following 4x4 matrix M:
+    |  1   |  2   |  3   |  4   |
+    |  5.5 |  6.5 |  7.5 |  8.5 |
+    |  9   | 10   | 11   | 12   |
+    | 13.5 | 14.5 | 15.5 | 16.5 |
+  Then M[0,0] = 1
+    And M[0,3] = 4
+    And M[1,0] = 5.5
+    And M[1,2] = 7.5
+    And M[2,2] = 11
+    And M[3,0] = 13.5
+    And M[3,2] = 15.5
+
+Scenario: A 2x2 matrix ought to be representable
+  Given the following 2x2 matrix M:
+    | -3 |  5 |
+    |  1 | -2 |
+  Then M[0,0] = -3
+    And M[0,1] = 5
+    And M[1,0] = 1
+    And M[1,1] = -2
+
+Scenario: A 3x3 matrix ought to be representable
+  Given the following 3x3 matrix M:
+    | -3 |  5 |  0 |
+    |  1 | -2 | -7 |
+    |  0 |  1 |  1 |
+  Then M[0,0] = -3
+    And M[1,1] = -2
+    And M[2,2] = 1
+
+Scenario: Matrix equality with identical matrices
+  Given the following matrix A:
+      | 1 | 2 | 3 | 4 |
+      | 5 | 6 | 7 | 8 |
+      | 9 | 8 | 7 | 6 |
+      | 5 | 4 | 3 | 2 |
+    And the following matrix B:
+      | 1 | 2 | 3 | 4 |
+      | 5 | 6 | 7 | 8 |
+      | 9 | 8 | 7 | 6 |
+      | 5 | 4 | 3 | 2 |
+  Then A = B
+
+Scenario: Matrix equality with different matrices
+  Given the following matrix A:
+      | 1 | 2 | 3 | 4 |
+      | 5 | 6 | 7 | 8 |
+      | 9 | 8 | 7 | 6 |
+      | 5 | 4 | 3 | 2 |
+    And the following matrix B:
+      | 2 | 3 | 4 | 5 |
+      | 6 | 7 | 8 | 9 |
+      | 8 | 7 | 6 | 5 |
+      | 4 | 3 | 2 | 1 |
+  Then A != B
+
+Scenario: Multiplying two matrices
+  Given the following matrix A:
+      | 1 | 2 | 3 | 4 |
+      | 5 | 6 | 7 | 8 |
+      | 9 | 8 | 7 | 6 |
+      | 5 | 4 | 3 | 2 |
+    And the following matrix B:
+      | -2 | 1 | 2 |  3 |
+      |  3 | 2 | 1 | -1 |
+      |  4 | 3 | 6 |  5 |
+      |  1 | 2 | 7 |  8 |
+  Then A * B is the following 4x4 matrix:
+      | 20|  22 |  50 |  48 |
+      | 44|  54 | 114 | 108 |
+      | 40|  58 | 110 | 102 |
+      | 16|  26 |  46 |  42 |
+
+Scenario: A matrix multiplied by a tuple
+  Given the following matrix A:
+      | 1 | 2 | 3 | 4 |
+      | 2 | 4 | 4 | 2 |
+      | 8 | 6 | 4 | 1 |
+      | 0 | 0 | 0 | 1 |
+    And b ← tuple(1, 2, 3, 1)
+  Then A * b = tuple(18, 24, 33, 1)
+
+Scenario: Multiplying a matrix by the identity matrix
+  Given the following matrix A:
+    | 0 | 1 |  2 |  4 |
+    | 1 | 2 |  4 |  8 |
+    | 2 | 4 |  8 | 16 |
+    | 4 | 8 | 16 | 32 |
+  Then A * identity_matrix = A
+
+Scenario: Multiplying the identity matrix by a tuple
+  Given a ← tuple(1, 2, 3, 4)
+  Then identity_matrix * a = a
+
+Scenario: Transposing a matrix
+  Given the following matrix A:
+    | 0 | 9 | 3 | 0 |
+    | 9 | 8 | 0 | 8 |
+    | 1 | 8 | 5 | 3 |
+    | 0 | 0 | 5 | 8 |
+  Then transpose(A) is the following matrix:
+    | 0 | 9 | 1 | 0 |
+    | 9 | 8 | 8 | 0 |
+    | 3 | 0 | 5 | 5 |
+    | 0 | 8 | 3 | 8 |
+
+Scenario: Transposing the identity matrix
+  Given A ← transpose(identity_matrix)
+  Then A = identity_matrix
+
+Scenario: Calculating the determinant of a 2x2 matrix
+  Given the following 2x2 matrix A:
+    |  1 | 5 |
+    | -3 | 2 |
+  Then determinant(A) = 17
+
+Scenario: A submatrix of a 3x3 matrix is a 2x2 matrix
+  Given the following 3x3 matrix A:
+    |  1 | 5 |  0 |
+    | -3 | 2 |  7 |
+    |  0 | 6 | -3 |
+  Then submatrix(A, 0, 2) is the following 2x2 matrix:
+    | -3 | 2 |
+    |  0 | 6 |
+
+Scenario: A submatrix of a 4x4 matrix is a 3x3 matrix
+  Given the following 4x4 matrix A:
+    | -6 |  1 |  1 |  6 |
+    | -8 |  5 |  8 |  6 |
+    | -1 |  0 |  8 |  2 |
+    | -7 |  1 | -1 |  1 |
+  Then submatrix(A, 2, 1) is the following 3x3 matrix:
+    | -6 |  1 | 6 |
+    | -8 |  8 | 6 |
+    | -7 | -1 | 1 |
+
+Scenario: Calculating a minor of a 3x3 matrix
+  Given the following 3x3 matrix A:
+      |  3 |  5 |  0 |
+      |  2 | -1 | -7 |
+      |  6 | -1 |  5 |
+    And B ← submatrix(A, 1, 0)
+  Then determinant(B) = 25
+    And minor(A, 1, 0) = 25
+
+Scenario: Calculating a cofactor of a 3x3 matrix
+  Given the following 3x3 matrix A:
+      |  3 |  5 |  0 |
+      |  2 | -1 | -7 |
+      |  6 | -1 |  5 |
+  Then minor(A, 0, 0) = -12
+    And cofactor(A, 0, 0) = -12
+    And minor(A, 1, 0) = 25
+    And cofactor(A, 1, 0) = -25
+
+Scenario: Calculating the determinant of a 3x3 matrix
+  Given the following 3x3 matrix A:
+    |  1 |  2 |  6 |
+    | -5 |  8 | -4 |
+    |  2 |  6 |  4 |
+  Then cofactor(A, 0, 0) = 56
+    And cofactor(A, 0, 1) = 12
+    And cofactor(A, 0, 2) = -46
+    And determinant(A) = -196
+
+Scenario: Calculating the determinant of a 4x4 matrix
+  Given the following 4x4 matrix A:
+    | -2 | -8 |  3 |  5 |
+    | -3 |  1 |  7 |  3 |
+    |  1 |  2 | -9 |  6 |
+    | -6 |  7 |  7 | -9 |
+  Then cofactor(A, 0, 0) = 690
+    And cofactor(A, 0, 1) = 447
+    And cofactor(A, 0, 2) = 210
+    And cofactor(A, 0, 3) = 51
+    And determinant(A) = -4071
+
+Scenario: Testing an invertible matrix for invertibility
+  Given the following 4x4 matrix A:
+    |  6 |  4 |  4 |  4 |
+    |  5 |  5 |  7 |  6 |
+    |  4 | -9 |  3 | -7 |
+    |  9 |  1 |  7 | -6 |
+  Then determinant(A) = -2120
+    And A is invertible
+
+Scenario: Testing a noninvertible matrix for invertibility
+  Given the following 4x4 matrix A:
+    | -4 |  2 | -2 | -3 |
+    |  9 |  6 |  2 |  6 |
+    |  0 | -5 |  1 | -5 |
+    |  0 |  0 |  0 |  0 |
+  Then determinant(A) = 0
+    And A is not invertible
+
+Scenario: Calculating the inverse of a matrix
+  Given the following 4x4 matrix A:
+      | -5 |  2 |  6 | -8 |
+      |  1 | -5 |  1 |  8 |
+      |  7 |  7 | -6 | -7 |
+      |  1 | -3 |  7 |  4 |
+    And B ← inverse(A)
+  Then determinant(A) = 532
+    And cofactor(A, 2, 3) = -160
+    And B[3,2] = -160/532
+    And cofactor(A, 3, 2) = 105
+    And B[2,3] = 105/532
+    And B is the following 4x4 matrix:
+      |  0.21805 |  0.45113 |  0.24060 | -0.04511 |
+      | -0.80827 | -1.45677 | -0.44361 |  0.52068 |
+      | -0.07895 | -0.22368 | -0.05263 |  0.19737 |
+      | -0.52256 | -0.81391 | -0.30075 |  0.30639 |
+
+Scenario: Calculating the inverse of another matrix
+  Given the following 4x4 matrix A:
+    |  8 | -5 |  9 |  2 |
+    |  7 |  5 |  6 |  1 |
+    | -6 |  0 |  9 |  6 |
+    | -3 |  0 | -9 | -4 |
+  Then inverse(A) is the following 4x4 matrix:
+    | -0.15385 | -0.15385 | -0.28205 | -0.53846 |
+    | -0.07692 |  0.12308 |  0.02564 |  0.03077 |
+    |  0.35897 |  0.35897 |  0.43590 |  0.92308 |
+    | -0.69231 | -0.69231 | -0.76923 | -1.92308 |
+
+Scenario: Calculating the inverse of a third matrix
+  Given the following 4x4 matrix A:
+    |  9 |  3 |  0 |  9 |
+    | -5 | -2 | -6 | -3 |
+    | -4 |  9 |  6 |  4 |
+    | -7 |  6 |  6 |  2 |
+  Then inverse(A) is the following 4x4 matrix:
+    | -0.04074 | -0.07778 |  0.14444 | -0.22222 |
+    | -0.07778 |  0.03333 |  0.36667 | -0.33333 |
+    | -0.02901 | -0.14630 | -0.10926 |  0.12963 |
+    |  0.17778 |  0.06667 | -0.26667 |  0.33333 |
+
+Scenario: Multiplying a product by its inverse
+  Given the following 4x4 matrix A:
+      |  3 | -9 |  7 |  3 |
+      |  3 | -8 |  2 | -9 |
+      | -4 |  4 |  4 |  1 |
+      | -6 |  5 | -1 |  1 |
+    And the following 4x4 matrix B:
+      |  8 |  2 |  2 |  2 |
+      |  3 | -1 |  7 |  0 |
+      |  7 |  0 |  5 |  4 |
+      |  6 | -2 |  0 |  5 |
+    And C ← A * B
+  Then C * inverse(B) = A

--- a/python/features/steps/matrices.py
+++ b/python/features/steps/matrices.py
@@ -1,0 +1,211 @@
+import pytest
+from behave import given, then, use_step_matcher
+
+from rayz.math_parser import parse_math
+from rayz.matrix import Matrix
+from rayz.tuple import Tuple
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_I = r"(\d+)"
+_A = r"([^\s,)]+)"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+IDENTITY_MATRIX = Matrix.identity(4)
+
+
+def _matrix_from_table(table) -> Matrix:
+    # Behave treats the first table row as headings, so include it as the first data row.
+    heading_row = [parse_math(h) for h in table.headings]
+    data_rows = [[parse_math(cell) for cell in row.cells] for row in table.rows]
+    return Matrix([heading_row] + data_rows)
+
+
+def _resolve(context, name: str) -> Matrix:
+    """Return the named matrix, treating 'identity_matrix' as a constant."""
+    if name == "identity_matrix":
+        return IDENTITY_MATRIX
+    return getattr(context, name)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+@given(rf"the following (?:\d+x\d+ )?matrix {_V}:")
+def step_given_matrix(context, var):
+    setattr(context, var, _matrix_from_table(context.table))
+
+
+# ---------------------------------------------------------------------------
+# Derived assignments
+# ---------------------------------------------------------------------------
+
+
+@given(rf"{_V} ← transpose\(identity_matrix\)")
+def step_given_transpose_identity(context, var):
+    setattr(context, var, IDENTITY_MATRIX.transpose())
+
+
+@given(rf"{_V} ← transpose\({_V}\)")
+def step_given_transpose(context, result, src):
+    setattr(context, result, _resolve(context, src).transpose())
+
+
+@given(rf"{_V} ← inverse\({_V}\)")
+def step_given_inverse(context, result, src):
+    setattr(context, result, _resolve(context, src).inverse())
+
+
+@given(rf"{_V} ← submatrix\({_V},\s*{_I},\s*{_I}\)")
+def step_given_submatrix(context, result, src, row, col):
+    setattr(context, result, _resolve(context, src).submatrix(int(row), int(col)))
+
+
+@given(rf"{_V} ← {_V} \* {_V}")
+def step_given_matrix_mul(context, result, a, b):
+    setattr(context, result, _resolve(context, a) * _resolve(context, b))
+
+
+# ---------------------------------------------------------------------------
+# Element access
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V}\[{_I},{_I}\] = {_A}")
+def step_then_element(context, var, row, col, val):
+    actual = _resolve(context, var)[int(row), int(col)]
+    assert actual == pytest.approx(parse_math(val), abs=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Equality / inequality
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V} = {_V}")
+def step_then_eq(context, a, b):
+    assert _resolve(context, a) == _resolve(context, b)
+
+
+@then(rf"{_V} != {_V}")
+def step_then_neq(context, a, b):
+    assert _resolve(context, a) != _resolve(context, b)
+
+
+# ---------------------------------------------------------------------------
+# Matrix multiplication result as table
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V} \* {_V} is the following (?:\d+x\d+ )?matrix:")
+def step_then_mul_matrix(context, a, b):
+    expected = _matrix_from_table(context.table)
+    assert _resolve(context, a) * _resolve(context, b) == expected
+
+
+@then(rf"{_V} \* identity_matrix = {_V}")
+def step_then_mul_identity(context, a, b):
+    assert _resolve(context, a) * IDENTITY_MATRIX == _resolve(context, b)
+
+
+@then(r"identity_matrix \* ([A-Za-z][A-Za-z0-9_]*) = ([A-Za-z][A-Za-z0-9_]*)")
+def step_then_identity_mul(context, a, b):
+    lhs = getattr(context, a)
+    if isinstance(lhs, Tuple):
+        result = IDENTITY_MATRIX * lhs
+        assert result == getattr(context, b)
+    else:
+        assert IDENTITY_MATRIX * _resolve(context, a) == _resolve(context, b)
+
+
+@then(rf"{_V} \* {_V} = tuple\({_A},\s*{_A},\s*{_A},\s*{_A}\)")
+def step_then_matrix_mul_tuple(context, mat, tup, x, y, z, w):
+    result = _resolve(context, mat) * getattr(context, tup)
+    expected = Tuple(parse_math(x), parse_math(y), parse_math(z), parse_math(w))
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# Transpose result as table
+# ---------------------------------------------------------------------------
+
+
+@then(rf"transpose\({_V}\) is the following (?:\d+x\d+ )?matrix:")
+def step_then_transpose(context, var):
+    expected = _matrix_from_table(context.table)
+    assert _resolve(context, var).transpose() == expected
+
+
+# ---------------------------------------------------------------------------
+# Determinant, submatrix, minor, cofactor
+# ---------------------------------------------------------------------------
+
+
+@then(rf"determinant\({_V}\) = {_A}")
+def step_then_determinant(context, var, val):
+    assert _resolve(context, var).determinant() == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"submatrix\({_V},\s*{_I},\s*{_I}\) is the following (?:\d+x\d+ )?matrix:")
+def step_then_submatrix(context, var, row, col):
+    expected = _matrix_from_table(context.table)
+    assert _resolve(context, var).submatrix(int(row), int(col)) == expected
+
+
+@then(rf"minor\({_V},\s*{_I},\s*{_I}\) = {_A}")
+def step_then_minor(context, var, row, col, val):
+    assert _resolve(context, var).minor(int(row), int(col)) == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"cofactor\({_V},\s*{_I},\s*{_I}\) = {_A}")
+def step_then_cofactor(context, var, row, col, val):
+    assert _resolve(context, var).cofactor(int(row), int(col)) == pytest.approx(parse_math(val), abs=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Invertibility
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V} is invertible")
+def step_then_invertible(context, var):
+    assert _resolve(context, var).is_invertible()
+
+
+@then(rf"{_V} is not invertible")
+def step_then_not_invertible(context, var):
+    assert not _resolve(context, var).is_invertible()
+
+
+# ---------------------------------------------------------------------------
+# Inverse result as table / expression
+# ---------------------------------------------------------------------------
+
+
+@then(rf"inverse\({_V}\) is the following (?:\d+x\d+ )?matrix:")
+def step_then_inverse_table(context, var):
+    expected = _matrix_from_table(context.table)
+    assert _resolve(context, var).inverse() == expected
+
+
+@then(rf"{_V} is the following (?:\d+x\d+ )?matrix:")
+def step_then_var_is_matrix(context, var):
+    expected = _matrix_from_table(context.table)
+    assert _resolve(context, var) == expected
+
+
+# ---------------------------------------------------------------------------
+# Multiply-then-inverse round-trip
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V} \* inverse\({_V}\) = {_V}")
+def step_then_mul_inverse_eq(context, c, b, a):
+    result = _resolve(context, c) * _resolve(context, b).inverse()
+    assert result == _resolve(context, a)

--- a/python/features/steps/matrices.py
+++ b/python/features/steps/matrices.py
@@ -160,12 +160,16 @@ def step_then_submatrix(context, var, row, col):
 
 @then(rf"minor\({_V},\s*{_I},\s*{_I}\) = {_A}")
 def step_then_minor(context, var, row, col, val):
-    assert _resolve(context, var).minor(int(row), int(col)) == pytest.approx(parse_math(val), abs=1e-5)
+    assert _resolve(context, var).minor(int(row), int(col)) == pytest.approx(
+        parse_math(val), abs=1e-5
+    )
 
 
 @then(rf"cofactor\({_V},\s*{_I},\s*{_I}\) = {_A}")
 def step_then_cofactor(context, var, row, col, val):
-    assert _resolve(context, var).cofactor(int(row), int(col)) == pytest.approx(parse_math(val), abs=1e-5)
+    assert _resolve(context, var).cofactor(int(row), int(col)) == pytest.approx(
+        parse_math(val), abs=1e-5
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/python/rayz/__init__.py
+++ b/python/rayz/__init__.py
@@ -3,6 +3,7 @@ from rayz.canvas import Canvas
 from rayz.color import Color
 from rayz.constants import EPSILON
 from rayz.environment import Environment
+from rayz.matrix import Matrix
 from rayz.projectile import Projectile
 from rayz.tuple import Point, Tuple, Vector
 
@@ -11,6 +12,7 @@ __all__ = [
     "Color",
     "EPSILON",
     "Environment",
+    "Matrix",
     "Point",
     "Projectile",
     "Tuple",

--- a/python/rayz/math_parser.py
+++ b/python/rayz/math_parser.py
@@ -36,4 +36,9 @@ def parse_math(text: str) -> float:
         divisor = float(pi_match.group(1)) if pi_match.group(1) else 1.0
         return math.pi / divisor
 
+    # Plain integer fraction like -160/532 or 105/532
+    frac_match = re.fullmatch(r"(-?\d+)/(\d+)", text)
+    if frac_match:
+        return float(frac_match.group(1)) / float(frac_match.group(2))
+
     return float(text)

--- a/python/rayz/matrix.py
+++ b/python/rayz/matrix.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import numpy as np
+
+from rayz.constants import EPSILON
+from rayz.tuple import Tuple
+
+
+class Matrix:
+    """An NxN matrix backed by a NumPy array."""
+
+    def __init__(self, rows: list[list[float]] | np.ndarray) -> None:
+        if isinstance(rows, np.ndarray):
+            self._data = rows.astype(float)
+        else:
+            self._data = np.array(rows, dtype=float)
+
+    # ------------------------------------------------------------------
+    # Element access
+    # ------------------------------------------------------------------
+
+    def __getitem__(self, key: tuple[int, int]) -> float:
+        return float(self._data[key])
+
+    # ------------------------------------------------------------------
+    # Equality
+    # ------------------------------------------------------------------
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Matrix):
+            return NotImplemented
+        if self._data.shape != other._data.shape:
+            return False
+        return bool(np.all(np.abs(self._data - other._data) < EPSILON))
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __repr__(self) -> str:
+        return f"Matrix({self._data.tolist()})"
+
+    # ------------------------------------------------------------------
+    # Multiplication
+    # ------------------------------------------------------------------
+
+    def __mul__(self, other: Matrix | Tuple) -> Matrix | Tuple:
+        if isinstance(other, Matrix):
+            return Matrix(self._data @ other._data)
+        if isinstance(other, Tuple):
+            vec = np.array([other.x, other.y, other.z, other.w])
+            result = self._data @ vec
+            return Tuple(result[0], result[1], result[2], result[3])
+        return NotImplemented
+
+    # ------------------------------------------------------------------
+    # Transpose
+    # ------------------------------------------------------------------
+
+    def transpose(self) -> Matrix:
+        return Matrix(self._data.T.copy())
+
+    # ------------------------------------------------------------------
+    # Determinant
+    # ------------------------------------------------------------------
+
+    def determinant(self) -> float:
+        n = self._data.shape[0]
+        if n == 2:
+            return float(self._data[0, 0] * self._data[1, 1] - self._data[0, 1] * self._data[1, 0])
+        total = 0.0
+        for col in range(n):
+            total += self._data[0, col] * self.cofactor(0, col)
+        return total
+
+    # ------------------------------------------------------------------
+    # Submatrix, minor, cofactor
+    # ------------------------------------------------------------------
+
+    def submatrix(self, row: int, col: int) -> Matrix:
+        """Return this matrix with the given row and column removed."""
+        data = np.delete(np.delete(self._data, row, axis=0), col, axis=1)
+        return Matrix(data)
+
+    def minor(self, row: int, col: int) -> float:
+        """Determinant of the submatrix at (row, col)."""
+        return self.submatrix(row, col).determinant()
+
+    def cofactor(self, row: int, col: int) -> float:
+        """Signed minor — negated when (row + col) is odd."""
+        m = self.minor(row, col)
+        return -m if (row + col) % 2 == 1 else m
+
+    # ------------------------------------------------------------------
+    # Invertibility and inverse
+    # ------------------------------------------------------------------
+
+    def is_invertible(self) -> bool:
+        return abs(self.determinant()) > EPSILON
+
+    def inverse(self) -> Matrix:
+        if not self.is_invertible():
+            raise ValueError("Matrix is not invertible")
+        return Matrix(np.linalg.inv(self._data))
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def identity(cls, size: int = 4) -> Matrix:
+        return cls(np.eye(size))


### PR DESCRIPTION
## Summary

- Adds `python/rayz/matrix.py` — `Matrix` class backed by NumPy with full book API: construction, equality (float tolerance), matrix × matrix, matrix × tuple, transpose, determinant, submatrix, minor, cofactor, invertibility check, and inverse
- Adds `python/features/matrices.feature` (copied from `book_features/`) and `python/features/steps/matrices.py` with 24 BDD scenarios, all passing
- Patches `math_parser.py` to handle plain integer fractions like `-160/532`

## Test plan

- [ ] `cd python && mise exec -- uv run behave features/` — 59 scenarios pass (35 pre-existing + 24 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)