### PR TITLE
Add Python Ch 4: Transformation matrices

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git push *)",
+            "command": "(cd /home/craig/workspace/rayz/python && mise exec -- uv run ruff check . && mise exec -- uv run ruff format --check .) && (cd /home/craig/workspace/rayz/ruby && mise exec -- bundle exec standardrb)",
+            "timeout": 60,
+            "statusMessage": "Running Python (ruff) and Ruby (standardrb) linters..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,9 +7,16 @@
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": "(cd /home/craig/workspace/rayz/python && mise exec -- uv run ruff check . && mise exec -- uv run ruff format --check .) && (cd /home/craig/workspace/rayz/ruby && mise exec -- bundle exec standardrb)",
+            "command": "cd /home/craig/workspace/rayz/python && mise exec -- uv run ruff check . && mise exec -- uv run ruff format --check .",
             "timeout": 60,
-            "statusMessage": "Running Python (ruff) and Ruby (standardrb) linters..."
+            "statusMessage": "Python: running ruff check and format..."
+          },
+          {
+            "type": "command",
+            "if": "Bash(git push *)",
+            "command": "cd /home/craig/workspace/rayz/ruby && mise exec -- bundle exec standardrb",
+            "timeout": 60,
+            "statusMessage": "Ruby: running standardrb..."
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
-.claude
+.claude/settings.local.json
+.claude/transcripts/
 /.bundle/
 /vendor/
 /tmp/

--- a/python/examples/chapter4.py
+++ b/python/examples/chapter4.py
@@ -1,0 +1,160 @@
+"""Chapter 4: Transformation matrices — translation, scaling, rotation, shearing, and a clock demo."""
+from __future__ import annotations
+
+import math
+import os
+
+from rayz.canvas import Canvas
+from rayz.color import Color
+from rayz.transformations import rotation_y, scaling, shearing, translation
+from rayz.tuple import Point, Vector
+
+
+def _draw_dot(canvas: Canvas, cx: int, cy: int, radius: int, color: Color) -> None:
+    for dx in range(-radius, radius + 1):
+        for dy in range(-radius, radius + 1):
+            if dx * dx + dy * dy <= radius * radius:
+                px, py = cx + dx, cy + dy
+                if 0 <= px < canvas.width and 0 <= py < canvas.height:
+                    canvas.write_pixel(col=px, row=py, color=color)
+
+
+def _draw_line(canvas: Canvas, x0: int, y0: int, x1: int, y1: int, color: Color) -> None:
+    """Bresenham's line algorithm."""
+    dx, dy = abs(x1 - x0), abs(y1 - y0)
+    sx = 1 if x0 < x1 else -1
+    sy = 1 if y0 < y1 else -1
+    err = dx - dy
+    while True:
+        if 0 <= x0 < canvas.width and 0 <= y0 < canvas.height:
+            canvas.write_pixel(col=x0, row=y0, color=color)
+        if x0 == x1 and y0 == y1:
+            break
+        e2 = 2 * err
+        if e2 > -dy:
+            err -= dy
+            x0 += sx
+        if e2 < dx:
+            err += dx
+            y0 += sy
+
+
+def demo_translation() -> None:
+    print("1. Translation")
+    print("-" * 40)
+    transform = translation(5, -3, 2)
+    p = Point(-3, 4, 5)
+    result = transform * p
+    print(f"  point(-3, 4, 5) + translation(5, -3, 2) = {result!r}")
+
+    v = Vector(-3, 4, 5)
+    v_result = transform * v
+    print(f"  vector(-3, 4, 5) + translation (vectors unaffected) = {v_result!r}")
+    print()
+
+
+def demo_scaling() -> None:
+    print("2. Scaling and Reflection")
+    print("-" * 40)
+    transform = scaling(2, 3, 4)
+    p = Point(-4, 6, 8)
+    result = transform * p
+    print(f"  point(-4, 6, 8) * scaling(2, 3, 4) = {result!r}")
+
+    reflect = scaling(-1, 1, 1)
+    result2 = reflect * Point(2, 3, 4)
+    print(f"  point(2, 3, 4) * scaling(-1, 1, 1) = {result2!r}  (reflection across YZ plane)")
+    print()
+
+
+def demo_rotation() -> None:
+    print("3. Rotation")
+    print("-" * 40)
+    p = Point(0, 0, 1)
+    r45 = rotation_y(math.pi / 4)
+    r90 = rotation_y(math.pi / 2)
+    print(f"  point(0, 0, 1) rotated around Y by π/4: {r45 * p!r}")
+    print(f"  point(0, 0, 1) rotated around Y by π/2: {r90 * p!r}")
+    print()
+
+
+def demo_shearing() -> None:
+    print("4. Shearing")
+    print("-" * 40)
+    p = Point(2, 3, 4)
+    transform = shearing(1, 0, 0, 0, 0, 0)
+    result = transform * p
+    print(f"  point(2, 3, 4) * shearing(1,0,0,0,0,0) = {result!r}  (x += y)")
+    print()
+
+
+def demo_chaining() -> None:
+    print("5. Chained Transformations")
+    print("-" * 40)
+    from rayz.transformations import rotation_x
+
+    p = Point(1, 0, 1)
+    A = rotation_x(math.pi / 2)
+    B = scaling(5, 5, 5)
+    C = translation(10, 5, 7)
+
+    p2 = A * p
+    p3 = B * p2
+    p4 = C * p3
+    print(f"  After rotation:    {p2!r}")
+    print(f"  After scaling:     {p3!r}")
+    print(f"  After translation: {p4!r}")
+
+    T = C * B * A
+    chained = T * p
+    print(f"  Chained (C*B*A)*p: {chained!r}  (matches: {chained == p4})")
+    print()
+
+
+def demo_analog_clock() -> None:
+    print("6. Analog Clock — showing 3:00")
+    print("-" * 40)
+
+    canvas = Canvas(width=500, height=500)
+    white = Color(1.0, 1.0, 1.0)
+    red = Color(1.0, 0.0, 0.0)
+    yellow = Color(1.0, 1.0, 0.0)
+    cx, cy, radius = 250, 250, 180
+
+    for hour in range(12):
+        angle = hour * (math.pi / 6.0)
+        twelve = Point(0, 0, radius)
+        pos = rotation_y(angle) * twelve
+        hx, hy = cx + round(pos.x), cy + round(pos.z)
+
+        color = red if hour == 0 else (yellow if hour % 3 == 0 else white)
+        dot_size = 4 if hour % 3 == 0 else 3
+        _draw_dot(canvas, hx, hy, dot_size, color)
+
+    # Hour hand at 3:00 (90°)
+    hour_tip = rotation_y(math.pi / 2) * Point(0, 0, 100)
+    _draw_line(canvas, cx, cy, cx + round(hour_tip.x), cy + round(hour_tip.z), red)
+
+    # Minute hand at 12:00 (0°)
+    _draw_line(canvas, cx, cy, cx, cy - 140, white)
+
+    out_path = os.path.join(os.path.dirname(__file__), "chapter4.ppm")
+    print(f"  Writing {out_path}...", end="", flush=True)
+    with open(out_path, "w") as f:
+        f.write(canvas.to_ppm())
+    print(" done.")
+    print("\n" + "=" * 60 + "\n")
+
+
+def run() -> None:
+    print("\n=== Chapter 4: Matrix Transformations ===\n")
+    demo_translation()
+    demo_scaling()
+    demo_rotation()
+    demo_shearing()
+    demo_chaining()
+    demo_analog_clock()
+
+
+if __name__ == "__main__":
+    run()

--- a/python/examples/chapter4.py
+++ b/python/examples/chapter4.py
@@ -1,4 +1,5 @@
 """Chapter 4: Transformation matrices — translation, scaling, rotation, shearing, and a clock demo."""
+
 from __future__ import annotations
 
 import math

--- a/python/examples/run.py
+++ b/python/examples/run.py
@@ -12,11 +12,13 @@ import sys
 from examples.chapter1 import run as ch1
 from examples.chapter2 import run as ch2
 from examples.chapter3 import run as ch3
+from examples.chapter4 import run as ch4
 
 CHAPTERS: dict[int, tuple[str, object]] = {
     1: ("Projectile physics", ch1),
     2: ("Canvas & PPM export", ch2),
     3: ("Matrices", ch3),
+    4: ("Transformations", ch4),
 }
 
 

--- a/python/features/steps/matrices.py
+++ b/python/features/steps/matrices.py
@@ -160,16 +160,12 @@ def step_then_submatrix(context, var, row, col):
 
 @then(rf"minor\({_V},\s*{_I},\s*{_I}\) = {_A}")
 def step_then_minor(context, var, row, col, val):
-    assert _resolve(context, var).minor(int(row), int(col)) == pytest.approx(
-        parse_math(val), abs=1e-5
-    )
+    assert _resolve(context, var).minor(int(row), int(col)) == pytest.approx(parse_math(val), abs=1e-5)
 
 
 @then(rf"cofactor\({_V},\s*{_I},\s*{_I}\) = {_A}")
 def step_then_cofactor(context, var, row, col, val):
-    assert _resolve(context, var).cofactor(int(row), int(col)) == pytest.approx(
-        parse_math(val), abs=1e-5
-    )
+    assert _resolve(context, var).cofactor(int(row), int(col)) == pytest.approx(parse_math(val), abs=1e-5)
 
 
 # ---------------------------------------------------------------------------

--- a/python/features/steps/transformations.py
+++ b/python/features/steps/transformations.py
@@ -66,9 +66,12 @@ def step_given_shearing(context, var, xy, xz, yx, yz, zx, zy):
         context,
         var,
         shearing(
-            parse_math(xy), parse_math(xz),
-            parse_math(yx), parse_math(yz),
-            parse_math(zx), parse_math(zy),
+            parse_math(xy),
+            parse_math(xz),
+            parse_math(yx),
+            parse_math(yz),
+            parse_math(zx),
+            parse_math(zy),
         ),
     )
 

--- a/python/features/steps/transformations.py
+++ b/python/features/steps/transformations.py
@@ -1,0 +1,137 @@
+import pytest
+from behave import given, then, use_step_matcher, when
+
+from rayz.math_parser import parse_math
+from rayz.transformations import (
+    rotation_x,
+    rotation_y,
+    rotation_z,
+    scaling,
+    shearing,
+    translation,
+    view_transform,
+)
+from rayz.tuple import Point, Vector
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+
+
+def _get(context, name):
+    return getattr(context, name)
+
+
+def _p(x, y, z):
+    return Point(parse_math(x), parse_math(y), parse_math(z))
+
+
+def _v(x, y, z):
+    return Vector(parse_math(x), parse_math(y), parse_math(z))
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+@given(rf"{_V} ← translation\({_A},\s*{_A},\s*{_A}\)")
+def step_given_translation(context, var, x, y, z):
+    setattr(context, var, translation(parse_math(x), parse_math(y), parse_math(z)))
+
+
+@given(rf"{_V} ← scaling\({_A},\s*{_A},\s*{_A}\)")
+def step_given_scaling(context, var, x, y, z):
+    setattr(context, var, scaling(parse_math(x), parse_math(y), parse_math(z)))
+
+
+@given(rf"{_V} ← rotation_x\(([^)]+)\)")
+def step_given_rotation_x(context, var, r):
+    setattr(context, var, rotation_x(parse_math(r)))
+
+
+@given(rf"{_V} ← rotation_y\(([^)]+)\)")
+def step_given_rotation_y(context, var, r):
+    setattr(context, var, rotation_y(parse_math(r)))
+
+
+@given(rf"{_V} ← rotation_z\(([^)]+)\)")
+def step_given_rotation_z(context, var, r):
+    setattr(context, var, rotation_z(parse_math(r)))
+
+
+@given(rf"{_V} ← shearing\({_A},\s*{_A},\s*{_A},\s*{_A},\s*{_A},\s*{_A}\)")
+def step_given_shearing(context, var, xy, xz, yx, yz, zx, zy):
+    setattr(
+        context,
+        var,
+        shearing(
+            parse_math(xy), parse_math(xz),
+            parse_math(yx), parse_math(yz),
+            parse_math(zx), parse_math(zy),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# When
+# ---------------------------------------------------------------------------
+
+
+@when(rf"{_V} ← view_transform\({_V},\s*{_V},\s*{_V}\)")
+def step_when_view_transform(context, var, frm, to, up):
+    setattr(context, var, view_transform(_get(context, frm), _get(context, to), _get(context, up)))
+
+
+@when(rf"{_V} ← {_V} \* {_V} \* {_V}")
+def step_when_triple_mul(context, result, a, b, c):
+    setattr(context, result, _get(context, a) * _get(context, b) * _get(context, c))
+
+
+@when(rf"{_V} ← {_V} \* {_V}")
+def step_when_mul(context, result, a, b):
+    setattr(context, result, _get(context, a) * _get(context, b))
+
+
+# ---------------------------------------------------------------------------
+# Then: matrix * var assertions
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V} \* {_V} = point\({_A},\s*{_A},\s*{_A}\)")
+def step_then_mul_point(context, mat, var, x, y, z):
+    result = _get(context, mat) * _get(context, var)
+    assert result == _p(x, y, z), f"{result!r} != point({x}, {y}, {z})"
+
+
+@then(rf"{_V} \* {_V} = vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_mul_vector(context, mat, var, x, y, z):
+    result = _get(context, mat) * _get(context, var)
+    assert result == _v(x, y, z), f"{result!r} != vector({x}, {y}, {z})"
+
+
+@then(rf"{_V} \* {_V} = {_V}")
+def step_then_mul_var(context, mat, operand, expected):
+    result = _get(context, mat) * _get(context, operand)
+    assert result == _get(context, expected), f"{result!r} != {expected}"
+
+
+# ---------------------------------------------------------------------------
+# Then: variable equality assertions
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V} = point\({_A},\s*{_A},\s*{_A}\)")
+def step_then_var_is_point(context, var, x, y, z):
+    assert _get(context, var) == _p(x, y, z)
+
+
+@then(rf"{_V} = scaling\({_A},\s*{_A},\s*{_A}\)")
+def step_then_var_is_scaling(context, var, x, y, z):
+    assert _get(context, var) == scaling(parse_math(x), parse_math(y), parse_math(z))
+
+
+@then(rf"{_V} = translation\({_A},\s*{_A},\s*{_A}\)")
+def step_then_var_is_translation(context, var, x, y, z):
+    assert _get(context, var) == translation(parse_math(x), parse_math(y), parse_math(z))

--- a/python/features/steps/transformations.py
+++ b/python/features/steps/transformations.py
@@ -1,4 +1,3 @@
-import pytest
 from behave import given, then, use_step_matcher, when
 
 from rayz.math_parser import parse_math

--- a/python/features/transformations.feature
+++ b/python/features/transformations.feature
@@ -1,0 +1,150 @@
+Feature: Matrix Transformations
+
+Scenario: Multiplying by a translation matrix
+  Given transform ← translation(5, -3, 2)
+    And p ← point(-3, 4, 5)
+   Then transform * p = point(2, 1, 7)
+
+Scenario: Multiplying by the inverse of a translation matrix
+  Given transform ← translation(5, -3, 2)
+    And inv ← inverse(transform)
+    And p ← point(-3, 4, 5)
+   Then inv * p = point(-8, 7, 3)
+
+Scenario: Translation does not affect vectors
+  Given transform ← translation(5, -3, 2)
+    And v ← vector(-3, 4, 5)
+   Then transform * v = v
+
+Scenario: A scaling matrix applied to a point
+  Given transform ← scaling(2, 3, 4)
+    And p ← point(-4, 6, 8)
+   Then transform * p = point(-8, 18, 32)
+
+Scenario: A scaling matrix applied to a vector
+  Given transform ← scaling(2, 3, 4)
+    And v ← vector(-4, 6, 8)
+   Then transform * v = vector(-8, 18, 32)
+
+Scenario: Multiplying by the inverse of a scaling matrix
+  Given transform ← scaling(2, 3, 4)
+    And inv ← inverse(transform)
+    And v ← vector(-4, 6, 8)
+   Then inv * v = vector(-2, 2, 2)
+
+Scenario: Reflection is scaling by a negative value
+  Given transform ← scaling(-1, 1, 1)
+    And p ← point(2, 3, 4)
+   Then transform * p = point(-2, 3, 4)
+
+Scenario: Rotating a point around the x axis
+  Given p ← point(0, 1, 0)
+    And half_quarter ← rotation_x(π / 4)
+    And full_quarter ← rotation_x(π / 2)
+  Then half_quarter * p = point(0, √2/2, √2/2)
+    And full_quarter * p = point(0, 0, 1)
+
+Scenario: The inverse of an x-rotation rotates in the opposite direction
+  Given p ← point(0, 1, 0)
+    And half_quarter ← rotation_x(π / 4)
+    And inv ← inverse(half_quarter)
+  Then inv * p = point(0, √2/2, -√2/2)
+
+Scenario: Rotating a point around the y axis
+  Given p ← point(0, 0, 1)
+    And half_quarter ← rotation_y(π / 4)
+    And full_quarter ← rotation_y(π / 2)
+  Then half_quarter * p = point(√2/2, 0, √2/2)
+    And full_quarter * p = point(1, 0, 0)
+
+Scenario: Rotating a point around the z axis
+  Given p ← point(0, 1, 0)
+    And half_quarter ← rotation_z(π / 4)
+    And full_quarter ← rotation_z(π / 2)
+  Then half_quarter * p = point(-√2/2, √2/2, 0)
+    And full_quarter * p = point(-1, 0, 0)
+
+Scenario: A shearing transformation moves x in proportion to y
+  Given transform ← shearing(1, 0, 0, 0, 0, 0)
+    And p ← point(2, 3, 4)
+  Then transform * p = point(5, 3, 4)
+
+Scenario: A shearing transformation moves x in proportion to z
+  Given transform ← shearing(0, 1, 0, 0, 0, 0)
+    And p ← point(2, 3, 4)
+  Then transform * p = point(6, 3, 4)
+
+Scenario: A shearing transformation moves y in proportion to x
+  Given transform ← shearing(0, 0, 1, 0, 0, 0)
+    And p ← point(2, 3, 4)
+  Then transform * p = point(2, 5, 4)
+
+Scenario: A shearing transformation moves y in proportion to z
+  Given transform ← shearing(0, 0, 0, 1, 0, 0)
+    And p ← point(2, 3, 4)
+  Then transform * p = point(2, 7, 4)
+
+Scenario: A shearing transformation moves z in proportion to x
+  Given transform ← shearing(0, 0, 0, 0, 1, 0)
+    And p ← point(2, 3, 4)
+  Then transform * p = point(2, 3, 6)
+
+Scenario: A shearing transformation moves z in proportion to y
+  Given transform ← shearing(0, 0, 0, 0, 0, 1)
+    And p ← point(2, 3, 4)
+  Then transform * p = point(2, 3, 7)
+
+Scenario: Individual transformations are applied in sequence
+  Given p ← point(1, 0, 1)
+    And A ← rotation_x(π / 2)
+    And B ← scaling(5, 5, 5)
+    And C ← translation(10, 5, 7)
+  # apply rotation first
+  When p2 ← A * p
+  Then p2 = point(1, -1, 0)
+  # then apply scaling
+  When p3 ← B * p2
+  Then p3 = point(5, -5, 0)
+  # then apply translation
+  When p4 ← C * p3
+  Then p4 = point(15, 0, 7)
+
+Scenario: Chained transformations must be applied in reverse order
+  Given p ← point(1, 0, 1)
+    And A ← rotation_x(π / 2)
+    And B ← scaling(5, 5, 5)
+    And C ← translation(10, 5, 7)
+  When T ← C * B * A
+  Then T * p = point(15, 0, 7)
+
+Scenario: The transformation matrix for the default orientation
+  Given from ← point(0, 0, 0)
+    And to ← point(0, 0, -1)
+    And up ← vector(0, 1, 0)
+  When t ← view_transform(from, to, up)
+  Then t = identity_matrix
+
+Scenario: A view transformation matrix looking in positive z direction
+  Given from ← point(0, 0, 0)
+    And to ← point(0, 0, 1)
+    And up ← vector(0, 1, 0)
+  When t ← view_transform(from, to, up)
+  Then t = scaling(-1, 1, -1)
+
+Scenario: The view transformation moves the world
+  Given from ← point(0, 0, 8)
+    And to ← point(0, 0, 0)
+    And up ← vector(0, 1, 0)
+  When t ← view_transform(from, to, up)
+  Then t = translation(0, 0, -8)
+
+Scenario: An arbitrary view transformation
+  Given from ← point(1, 3, 2)
+    And to ← point(4, -2, 8)
+    And up ← vector(1, 1, 0)
+  When t ← view_transform(from, to, up)
+  Then t is the following 4x4 matrix:
+      | -0.50709 | 0.50709 |  0.67612 | -2.36643 |
+      |  0.76772 | 0.60609 |  0.12122 | -2.82843 |
+      | -0.35857 | 0.59761 | -0.71714 |  0.00000 |
+      |  0.00000 | 0.00000 |  0.00000 |  1.00000 |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,7 +18,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.ruff]
-line-length = 100
+line-length = 110
 target-version = "py313"
 
 [tool.ruff.lint]

--- a/python/rayz/math_parser.py
+++ b/python/rayz/math_parser.py
@@ -11,7 +11,7 @@ from rayz.constants import EPSILON
 
 
 def parse_math(text: str) -> float:
-    text = text.strip()
+    text = "".join(text.split())  # normalize: "π / 4" → "π/4"
 
     if text == "infinity":
         return float("inf")

--- a/python/rayz/transformations.py
+++ b/python/rayz/transformations.py
@@ -1,4 +1,5 @@
 """Transformation matrix factories for 3D graphics."""
+
 from __future__ import annotations
 
 import math
@@ -8,60 +9,72 @@ from rayz.tuple import Vector
 
 
 def translation(x: float, y: float, z: float) -> Matrix:
-    return Matrix([
-        [1, 0, 0, x],
-        [0, 1, 0, y],
-        [0, 0, 1, z],
-        [0, 0, 0, 1],
-    ])
+    return Matrix(
+        [
+            [1, 0, 0, x],
+            [0, 1, 0, y],
+            [0, 0, 1, z],
+            [0, 0, 0, 1],
+        ]
+    )
 
 
 def scaling(x: float, y: float, z: float) -> Matrix:
-    return Matrix([
-        [x, 0, 0, 0],
-        [0, y, 0, 0],
-        [0, 0, z, 0],
-        [0, 0, 0, 1],
-    ])
+    return Matrix(
+        [
+            [x, 0, 0, 0],
+            [0, y, 0, 0],
+            [0, 0, z, 0],
+            [0, 0, 0, 1],
+        ]
+    )
 
 
 def rotation_x(radians: float) -> Matrix:
     c, s = math.cos(radians), math.sin(radians)
-    return Matrix([
-        [1, 0,  0, 0],
-        [0, c, -s, 0],
-        [0, s,  c, 0],
-        [0, 0,  0, 1],
-    ])
+    return Matrix(
+        [
+            [1, 0, 0, 0],
+            [0, c, -s, 0],
+            [0, s, c, 0],
+            [0, 0, 0, 1],
+        ]
+    )
 
 
 def rotation_y(radians: float) -> Matrix:
     c, s = math.cos(radians), math.sin(radians)
-    return Matrix([
-        [ c, 0, s, 0],
-        [ 0, 1, 0, 0],
-        [-s, 0, c, 0],
-        [ 0, 0, 0, 1],
-    ])
+    return Matrix(
+        [
+            [c, 0, s, 0],
+            [0, 1, 0, 0],
+            [-s, 0, c, 0],
+            [0, 0, 0, 1],
+        ]
+    )
 
 
 def rotation_z(radians: float) -> Matrix:
     c, s = math.cos(radians), math.sin(radians)
-    return Matrix([
-        [c, -s, 0, 0],
-        [s,  c, 0, 0],
-        [0,  0, 1, 0],
-        [0,  0, 0, 1],
-    ])
+    return Matrix(
+        [
+            [c, -s, 0, 0],
+            [s, c, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1],
+        ]
+    )
 
 
 def shearing(xy: float, xz: float, yx: float, yz: float, zx: float, zy: float) -> Matrix:
-    return Matrix([
-        [ 1, xy, xz, 0],
-        [yx,  1, yz, 0],
-        [zx, zy,  1, 0],
-        [ 0,  0,  0, 1],
-    ])
+    return Matrix(
+        [
+            [1, xy, xz, 0],
+            [yx, 1, yz, 0],
+            [zx, zy, 1, 0],
+            [0, 0, 0, 1],
+        ]
+    )
 
 
 def view_transform(from_pt, to_pt, up) -> Matrix:
@@ -71,11 +84,13 @@ def view_transform(from_pt, to_pt, up) -> Matrix:
     left = forward.cross(upn)
     true_up = left.cross(forward)
 
-    orientation = Matrix([
-        [ left.x,     left.y,     left.z,    0],
-        [ true_up.x,  true_up.y,  true_up.z, 0],
-        [-forward.x, -forward.y, -forward.z, 0],
-        [ 0,          0,          0,          1],
-    ])
+    orientation = Matrix(
+        [
+            [left.x, left.y, left.z, 0],
+            [true_up.x, true_up.y, true_up.z, 0],
+            [-forward.x, -forward.y, -forward.z, 0],
+            [0, 0, 0, 1],
+        ]
+    )
 
     return orientation * translation(-from_pt.x, -from_pt.y, -from_pt.z)

--- a/python/rayz/transformations.py
+++ b/python/rayz/transformations.py
@@ -1,0 +1,81 @@
+"""Transformation matrix factories for 3D graphics."""
+from __future__ import annotations
+
+import math
+
+from rayz.matrix import Matrix
+from rayz.tuple import Vector
+
+
+def translation(x: float, y: float, z: float) -> Matrix:
+    return Matrix([
+        [1, 0, 0, x],
+        [0, 1, 0, y],
+        [0, 0, 1, z],
+        [0, 0, 0, 1],
+    ])
+
+
+def scaling(x: float, y: float, z: float) -> Matrix:
+    return Matrix([
+        [x, 0, 0, 0],
+        [0, y, 0, 0],
+        [0, 0, z, 0],
+        [0, 0, 0, 1],
+    ])
+
+
+def rotation_x(radians: float) -> Matrix:
+    c, s = math.cos(radians), math.sin(radians)
+    return Matrix([
+        [1, 0,  0, 0],
+        [0, c, -s, 0],
+        [0, s,  c, 0],
+        [0, 0,  0, 1],
+    ])
+
+
+def rotation_y(radians: float) -> Matrix:
+    c, s = math.cos(radians), math.sin(radians)
+    return Matrix([
+        [ c, 0, s, 0],
+        [ 0, 1, 0, 0],
+        [-s, 0, c, 0],
+        [ 0, 0, 0, 1],
+    ])
+
+
+def rotation_z(radians: float) -> Matrix:
+    c, s = math.cos(radians), math.sin(radians)
+    return Matrix([
+        [c, -s, 0, 0],
+        [s,  c, 0, 0],
+        [0,  0, 1, 0],
+        [0,  0, 0, 1],
+    ])
+
+
+def shearing(xy: float, xz: float, yx: float, yz: float, zx: float, zy: float) -> Matrix:
+    return Matrix([
+        [ 1, xy, xz, 0],
+        [yx,  1, yz, 0],
+        [zx, zy,  1, 0],
+        [ 0,  0,  0, 1],
+    ])
+
+
+def view_transform(from_pt, to_pt, up) -> Matrix:
+    diff = to_pt - from_pt
+    forward = Vector(diff.x, diff.y, diff.z).normalize()
+    upn = Vector(up.x, up.y, up.z).normalize()
+    left = forward.cross(upn)
+    true_up = left.cross(forward)
+
+    orientation = Matrix([
+        [ left.x,     left.y,     left.z,    0],
+        [ true_up.x,  true_up.y,  true_up.z, 0],
+        [-forward.x, -forward.y, -forward.z, 0],
+        [ 0,          0,          0,          1],
+    ])
+
+    return orientation * translation(-from_pt.x, -from_pt.y, -from_pt.z)


### PR DESCRIPTION
## Summary

- Adds `rayz/transformations.py` with `translation`, `scaling`, `rotation_x/y/z`, `shearing`, and `view_transform` factory functions
- Copies `book_features/transformations.feature` → `features/transformations.feature` (23 scenarios, all passing)
- Adds `features/steps/transformations.py` with full BDD step coverage
- Adds `examples/chapter4.py` demo: analog clock face showing 3:00, plus console demos of each transform type
- Updates `examples/run.py` to include chapter 4
- Fixes `math_parser.py` to normalize whitespace so `π / 4` (with spaces) parses correctly

## Test plan

- [ ] `cd python && mise exec -- uv run behave features/transformations.feature` → 23/23 scenarios pass
- [ ] `cd python && mise exec -- uv run behave features/` → 82/82 scenarios pass (no regressions)
- [ ] `cd python && mise exec -- uv run examples/run.py 4` → runs demo and writes `examples/chapter4.ppm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)