### PR TITLE
Add Python Ch 5: Ray-sphere intersections

### DIFF
--- a/python/examples/chapter5.py
+++ b/python/examples/chapter5.py
@@ -1,0 +1,52 @@
+"""Chapter 5: Ray-sphere intersections — silhouette rendering."""
+
+from __future__ import annotations
+
+import os
+
+from rayz.canvas import Canvas
+from rayz.color import Color
+from rayz.intersection import hit, intersect
+from rayz.ray import Ray
+from rayz.sphere import Sphere
+from rayz.tuple import Point, Vector
+
+
+def run() -> None:
+    print("\n=== Chapter 5: Ray-Sphere Intersections ===\n")
+
+    sphere = Sphere()
+    canvas_size = 200
+    canvas = Canvas(canvas_size, canvas_size)
+    red = Color(1.0, 0.0, 0.0)
+
+    ray_origin = Point(0, 0, -5)
+    wall_z = 10.0
+    wall_size = 7.0
+    pixel_size = wall_size / canvas_size
+    half = wall_size / 2.0
+
+    print(f"Casting {canvas_size}x{canvas_size} rays at a unit sphere...")
+    for row in range(canvas_size):
+        world_y = half - pixel_size * row
+        for col in range(canvas_size):
+            world_x = -half + pixel_size * col
+            target = Point(world_x, world_y, wall_z)
+            diff = target - ray_origin
+            direction = Vector(diff.x, diff.y, diff.z).normalize()
+            r = Ray(ray_origin, direction)
+            xs = intersect(sphere, r)
+            if hit(xs) is not None:
+                canvas.write_pixel(col=col, row=row, color=red)
+
+    out_path = os.path.join(os.path.dirname(__file__), "chapter5.ppm")
+    print(f"Writing {out_path}...", end="", flush=True)
+    with open(out_path, "w") as f:
+        f.write(canvas.to_ppm())
+    print(" done.")
+    print("Sphere silhouette rendered via ray casting.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/examples/run.py
+++ b/python/examples/run.py
@@ -13,12 +13,14 @@ from examples.chapter1 import run as ch1
 from examples.chapter2 import run as ch2
 from examples.chapter3 import run as ch3
 from examples.chapter4 import run as ch4
+from examples.chapter5 import run as ch5
 
 CHAPTERS: dict[int, tuple[str, object]] = {
     1: ("Projectile physics", ch1),
     2: ("Canvas & PPM export", ch2),
     3: ("Matrices", ch3),
     4: ("Transformations", ch4),
+    5: ("Ray-sphere intersections", ch5),
 }
 
 

--- a/python/features/intersections.feature
+++ b/python/features/intersections.feature
@@ -1,0 +1,50 @@
+Feature: Intersections
+
+Scenario: An intersection encapsulates t and object
+  Given s ← sphere()
+  When i ← intersection(3.5, s)
+  Then i.t = 3.5
+    And i.object = s
+
+Scenario: Aggregating intersections
+  Given s ← sphere()
+    And i1 ← intersection(1, s)
+    And i2 ← intersection(2, s)
+  When xs ← intersections(i1, i2)
+  Then xs.count = 2
+    And xs[0].t = 1
+    And xs[1].t = 2
+
+Scenario: The hit, when all intersections have positive t
+  Given s ← sphere()
+    And i1 ← intersection(1, s)
+    And i2 ← intersection(2, s)
+    And xs ← intersections(i2, i1)
+  When i ← hit(xs)
+  Then i = i1
+
+Scenario: The hit, when some intersections have negative t
+  Given s ← sphere()
+    And i1 ← intersection(-1, s)
+    And i2 ← intersection(1, s)
+    And xs ← intersections(i2, i1)
+  When i ← hit(xs)
+  Then i = i2
+
+Scenario: The hit, when all intersections have negative t
+  Given s ← sphere()
+    And i1 ← intersection(-2, s)
+    And i2 ← intersection(-1, s)
+    And xs ← intersections(i2, i1)
+  When i ← hit(xs)
+  Then i is nothing
+
+Scenario: The hit is always the lowest nonnegative intersection
+  Given s ← sphere()
+  And i1 ← intersection(5, s)
+  And i2 ← intersection(7, s)
+  And i3 ← intersection(-3, s)
+  And i4 ← intersection(2, s)
+  And xs ← intersections(i1, i2, i3, i4)
+  When i ← hit(xs)
+  Then i = i4

--- a/python/features/rays.feature
+++ b/python/features/rays.feature
@@ -1,0 +1,29 @@
+Feature: Rays
+
+Scenario: Creating and querying a ray
+  Given origin ← point(1, 2, 3)
+    And direction ← vector(4, 5, 6)
+  When r ← ray(origin, direction)
+  Then r.origin = origin
+    And r.direction = direction
+
+Scenario: Computing a point from a distance
+  Given r ← ray(point(2, 3, 4), vector(1, 0, 0))
+  Then position(r, 0) = point(2, 3, 4)
+    And position(r, 1) = point(3, 3, 4)
+    And position(r, -1) = point(1, 3, 4)
+    And position(r, 2.5) = point(4.5, 3, 4)
+
+Scenario: Translating a ray
+  Given r ← ray(point(1, 2, 3), vector(0, 1, 0))
+    And m ← translation(3, 4, 5)
+  When r2 ← transform(r, m)
+  Then r2.origin = point(4, 6, 8)
+    And r2.direction = vector(0, 1, 0)
+
+Scenario: Scaling a ray
+  Given r ← ray(point(1, 2, 3), vector(0, 1, 0))
+    And m ← scaling(2, 3, 4)
+  When r2 ← transform(r, m)
+  Then r2.origin = point(2, 6, 12)
+    And r2.direction = vector(0, 3, 0)

--- a/python/features/spheres.feature
+++ b/python/features/spheres.feature
@@ -1,0 +1,129 @@
+Feature: Spheres
+
+Scenario: A ray intersects a sphere at two points
+  Given r ← ray(point(0, 0, -5), vector(0, 0, 1))
+    And s ← sphere()
+  When xs ← intersect(s, r)
+  Then xs.count = 2
+    And xs[0] = 4.0
+    And xs[1] = 6.0
+
+Scenario: A ray intersects a sphere at a tangent
+  Given r ← ray(point(0, 1, -5), vector(0, 0, 1))
+    And s ← sphere()
+  When xs ← intersect(s, r)
+  Then xs.count = 2
+    And xs[0] = 5.0
+    And xs[1] = 5.0
+
+Scenario: A ray misses a sphere
+  Given r ← ray(point(0, 2, -5), vector(0, 0, 1))
+    And s ← sphere()
+  When xs ← intersect(s, r)
+  Then xs.count = 0
+
+Scenario: A ray originates inside a sphere
+  Given r ← ray(point(0, 0, 0), vector(0, 0, 1))
+    And s ← sphere()
+  When xs ← intersect(s, r)
+  Then xs.count = 2
+    And xs[0] = -1.0
+    And xs[1] = 1.0
+
+Scenario: A sphere is behind a ray
+  Given r ← ray(point(0, 0, 5), vector(0, 0, 1))
+    And s ← sphere()
+  When xs ← intersect(s, r)
+  Then xs.count = 2
+    And xs[0] = -6.0
+    And xs[1] = -4.0
+
+Scenario: Intersect sets the object on the intersection
+  Given r ← ray(point(0, 0, -5), vector(0, 0, 1))
+    And s ← sphere()
+  When xs ← intersect(s, r)
+  Then xs.count = 2
+    And xs[0].object = s
+    And xs[1].object = s
+
+Scenario: A sphere's default transformation
+  Given s ← sphere()
+  Then s.transform = identity_matrix
+
+Scenario: Changing a sphere's transformation
+  Given s ← sphere()
+    And t ← translation(2, 3, 4)
+  When set_transform(s, t)
+  Then s.transform = t
+
+Scenario: Intersecting a scaled sphere with a ray
+  Given r ← ray(point(0, 0, -5), vector(0, 0, 1))
+    And s ← sphere()
+  When set_transform(s, scaling(2, 2, 2))
+    And xs ← intersect(s, r)
+  Then xs.count = 2
+    And xs[0].t = 3
+    And xs[1].t = 7
+
+Scenario: Intersecting a translated sphere with a ray
+  Given r ← ray(point(0, 0, -5), vector(0, 0, 1))
+    And s ← sphere()
+  When set_transform(s, translation(5, 0, 0))
+    And xs ← intersect(s, r)
+  Then xs.count = 0
+
+Scenario: The normal on a sphere at a point on the x axis
+  Given s ← sphere()
+  When n ← normal_at(s, point(1, 0, 0))
+  Then n = vector(1, 0, 0)
+
+Scenario: The normal on a sphere at a point on the y axis
+  Given s ← sphere()
+  When n ← normal_at(s, point(0, 1, 0))
+  Then n = vector(0, 1, 0)
+
+Scenario: The normal on a sphere at a point on the z axis
+  Given s ← sphere()
+  When n ← normal_at(s, point(0, 0, 1))
+  Then n = vector(0, 0, 1)
+
+Scenario: The normal on a sphere at a nonaxial point
+  Given s ← sphere()
+  When n ← normal_at(s, point(√3/3, √3/3, √3/3))
+  Then n = vector(√3/3, √3/3, √3/3)
+
+Scenario: The normal is a normalized vector
+  Given s ← sphere()
+  When n ← normal_at(s, point(√3/3, √3/3, √3/3))
+  Then n = normalize(n)
+
+Scenario: Computing the normal on a translated sphere
+  Given s ← sphere()
+    And set_transform(s, translation(0, 1, 0))
+  When n ← normal_at(s, point(0, 1.70711, -0.70711))
+  Then n = vector(0, 0.70711, -0.70711)
+
+Scenario: Computing the normal on a transformed sphere
+  Given s ← sphere()
+    And m ← scaling(1, 0.5, 1) * rotation_z(π/5)
+    And set_transform(s, m)
+  When n ← normal_at(s, point(0, √2/2, -√2/2))
+  Then n = vector(0, 0.97014, -0.24254)
+
+Scenario: A sphere has a default material
+  Given s ← sphere()
+  When m ← s.material
+  Then m = material()
+
+Scenario: A sphere may be assigned a material
+  Given s ← sphere()
+    And m ← material()
+    And m.ambient ← 1
+  When s.material ← m
+  Then s.material = m
+
+Scenario: A helper for producing a sphere with a glassy material
+  Given s ← glass_sphere()
+  Then s.transform = identity_matrix
+    And s.material.transparency = 1.0
+    And s.material.refractive_index = 1.5

--- a/python/features/steps/intersections.py
+++ b/python/features/steps/intersections.py
@@ -1,0 +1,89 @@
+import pytest
+from behave import given, then, use_step_matcher, when
+
+from rayz.intersection import Intersection, hit, intersections
+from rayz.math_parser import parse_math
+from rayz.sphere import Sphere
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+_I = r"(\d+)"
+
+
+# ---------------------------------------------------------------------------
+# Given: sphere and intersection setup
+# ---------------------------------------------------------------------------
+
+
+@given(rf"{_V} ← sphere\(\)")
+def step_given_sphere(context, var):
+    setattr(context, var, Sphere())
+
+
+@given(rf"{_V} ← intersection\({_A},\s*{_V}\)")
+def step_given_intersection(context, var, t, obj_var):
+    setattr(context, var, Intersection(parse_math(t), getattr(context, obj_var)))
+
+
+@given(rf"{_V} ← intersections\((.+)\)")
+def step_given_intersections(context, var, args):
+    items = [getattr(context, a.strip()) for a in args.split(",")]
+    setattr(context, var, intersections(*items))
+
+
+# ---------------------------------------------------------------------------
+# When
+# ---------------------------------------------------------------------------
+
+
+@when(rf"{_V} ← intersection\({_A},\s*{_V}\)")
+def step_when_intersection(context, var, t, obj_var):
+    setattr(context, var, Intersection(parse_math(t), getattr(context, obj_var)))
+
+
+@when(rf"{_V} ← intersections\((.+)\)")
+def step_when_intersections(context, var, args):
+    items = [getattr(context, a.strip()) for a in args.split(",")]
+    setattr(context, var, intersections(*items))
+
+
+@when(rf"{_V} ← hit\({_V}\)")
+def step_when_hit(context, var, xs_var):
+    setattr(context, var, hit(getattr(context, xs_var)))
+
+
+# ---------------------------------------------------------------------------
+# Then
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V}\.t = {_A}")
+def step_then_intersection_t(context, var, val):
+    assert getattr(context, var).t == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V}\.object = {_V}")
+def step_then_intersection_object(context, var, obj_var):
+    assert getattr(context, var).object is getattr(context, obj_var)
+
+
+@then(rf"{_V}\.count = {_I}")
+def step_then_xs_count(context, var, n):
+    assert len(getattr(context, var)) == int(n)
+
+
+@then(rf"{_V}\[{_I}\]\.t = {_A}")
+def step_then_xs_item_t(context, var, idx, val):
+    assert getattr(context, var)[int(idx)].t == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V}\[{_I}\]\.object = {_V}")
+def step_then_xs_item_object(context, xs_var, idx, obj_var):
+    assert getattr(context, xs_var)[int(idx)].object is getattr(context, obj_var)
+
+
+@then(rf"{_V} is nothing")
+def step_then_is_nothing(context, var):
+    assert getattr(context, var) is None

--- a/python/features/steps/rays.py
+++ b/python/features/steps/rays.py
@@ -1,0 +1,87 @@
+from behave import given, then, use_step_matcher, when
+
+from rayz.math_parser import parse_math
+from rayz.ray import Ray
+from rayz.transformations import scaling, translation
+from rayz.tuple import Point, Vector
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+@given(rf"{_V} ← ray\(point\({_A},\s*{_A},\s*{_A}\),\s*vector\({_A},\s*{_A},\s*{_A}\)\)")
+def step_given_ray_inline(context, var, ox, oy, oz, dx, dy, dz):
+    origin = Point(parse_math(ox), parse_math(oy), parse_math(oz))
+    direction = Vector(parse_math(dx), parse_math(dy), parse_math(dz))
+    setattr(context, var, Ray(origin, direction))
+
+
+@when(rf"{_V} ← ray\({_V},\s*{_V}\)")
+def step_when_ray_vars(context, var, orig, dirn):
+    setattr(context, var, Ray(getattr(context, orig), getattr(context, dirn)))
+
+
+# ---------------------------------------------------------------------------
+# Given: named transform matrices (reuse transform factories)
+# ---------------------------------------------------------------------------
+
+
+@given(rf"{_V} ← translation\({_A},\s*{_A},\s*{_A}\)")
+def step_given_translation(context, var, x, y, z):
+    setattr(context, var, translation(parse_math(x), parse_math(y), parse_math(z)))
+
+
+@given(rf"{_V} ← scaling\({_A},\s*{_A},\s*{_A}\)")
+def step_given_scaling(context, var, x, y, z):
+    setattr(context, var, scaling(parse_math(x), parse_math(y), parse_math(z)))
+
+
+# ---------------------------------------------------------------------------
+# When: transform a ray
+# ---------------------------------------------------------------------------
+
+
+@when(rf"{_V} ← transform\({_V},\s*{_V}\)")
+def step_when_transform_ray(context, result, ray_var, mat_var):
+    setattr(context, result, getattr(context, ray_var).transform(getattr(context, mat_var)))
+
+
+# ---------------------------------------------------------------------------
+# Then: ray component assertions
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V}\.origin = {_V}")
+def step_then_ray_origin_eq_var(context, ray_var, point_var):
+    assert getattr(context, ray_var).origin == getattr(context, point_var)
+
+
+@then(rf"{_V}\.direction = {_V}")
+def step_then_ray_direction_eq_var(context, ray_var, vec_var):
+    assert getattr(context, ray_var).direction == getattr(context, vec_var)
+
+
+@then(rf"{_V}\.origin = point\({_A},\s*{_A},\s*{_A}\)")
+def step_then_ray_origin_eq_point(context, ray_var, x, y, z):
+    expected = Point(parse_math(x), parse_math(y), parse_math(z))
+    assert getattr(context, ray_var).origin == expected
+
+
+@then(rf"{_V}\.direction = vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_ray_direction_eq_vector(context, ray_var, x, y, z):
+    expected = Vector(parse_math(x), parse_math(y), parse_math(z))
+    assert getattr(context, ray_var).direction == expected
+
+
+@then(rf"position\({_V},\s*{_A}\) = point\({_A},\s*{_A},\s*{_A}\)")
+def step_then_position(context, ray_var, t, x, y, z):
+    result = getattr(context, ray_var).position(parse_math(t))
+    expected = Point(parse_math(x), parse_math(y), parse_math(z))
+    assert result == expected, f"position({ray_var}, {t}) = {result!r}, expected {expected!r}"

--- a/python/features/steps/spheres.py
+++ b/python/features/steps/spheres.py
@@ -1,0 +1,197 @@
+import re
+
+import pytest
+from behave import given, then, use_step_matcher, when
+
+from rayz.intersection import intersect
+from rayz.material import Material
+from rayz.math_parser import parse_math
+from rayz.matrix import Matrix
+from rayz.ray import Ray
+from rayz.sphere import Sphere, glass_sphere
+from rayz.transformations import (
+    rotation_x,
+    rotation_y,
+    rotation_z,
+    scaling,
+    shearing,
+    translation,
+)
+from rayz.tuple import Point, Vector
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+_I = r"(\d+)"
+
+IDENTITY_MATRIX = Matrix.identity(4)
+
+_TRANSFORM_FUNCS = {
+    "scaling": scaling,
+    "translation": translation,
+    "rotation_x": rotation_x,
+    "rotation_y": rotation_y,
+    "rotation_z": rotation_z,
+    "shearing": shearing,
+}
+
+
+def _eval_transform(context, expr: str) -> Matrix:
+    """Evaluate a matrix expression: variable name or transform function call."""
+    expr = expr.strip()
+    m = re.fullmatch(r"(scaling|translation|rotation_x|rotation_y|rotation_z|shearing)\((.+)\)", expr)
+    if m:
+        func = _TRANSFORM_FUNCS[m.group(1)]
+        args = [parse_math(a.strip()) for a in m.group(2).split(",")]
+        return func(*args)
+    return getattr(context, expr)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+@given(rf"{_V} ← sphere\(\)")
+def step_given_sphere(context, var):
+    setattr(context, var, Sphere())
+
+
+@given(rf"{_V} ← glass_sphere\(\)")
+def step_given_glass_sphere(context, var):
+    setattr(context, var, glass_sphere())
+
+
+@given(rf"{_V} ← material\(\)")
+def step_given_material(context, var):
+    setattr(context, var, Material())
+
+
+@given(rf"{_V} ← ray\(point\({_A},\s*{_A},\s*{_A}\),\s*vector\({_A},\s*{_A},\s*{_A}\)\)")
+def step_given_ray(context, var, ox, oy, oz, dx, dy, dz):
+    setattr(
+        context,
+        var,
+        Ray(
+            Point(parse_math(ox), parse_math(oy), parse_math(oz)),
+            Vector(parse_math(dx), parse_math(dy), parse_math(dz)),
+        ),
+    )
+
+
+# Chained matrix: m ← expr1 * expr2
+@given(r"([A-Za-z][A-Za-z0-9_]*) ← (.+) \* (.+)")
+def step_given_matrix_mul_expr(context, var, expr1, expr2):
+    m1 = _eval_transform(context, expr1)
+    m2 = _eval_transform(context, expr2)
+    setattr(context, var, m1 * m2)
+
+
+# set_transform with variable or inline expression
+@given(rf"set_transform\({_V},\s*(.+)\)")
+def step_given_set_transform(context, var, expr):
+    getattr(context, var).set_transform(_eval_transform(context, expr))
+
+
+# m.ambient ← value
+@given(rf"{_V}\.ambient ← {_A}")
+def step_given_set_ambient(context, var, val):
+    getattr(context, var).ambient = parse_math(val)
+
+
+# ---------------------------------------------------------------------------
+# When
+# ---------------------------------------------------------------------------
+
+
+@when(rf"xs ← intersect\({_V},\s*{_V}\)")
+def step_when_intersect(context, shape_var, ray_var):
+    context.xs = intersect(getattr(context, shape_var), getattr(context, ray_var))
+
+
+@when(rf"set_transform\({_V},\s*(.+)\)")
+def step_when_set_transform(context, var, expr):
+    getattr(context, var).set_transform(_eval_transform(context, expr))
+
+
+@when(rf"n ← normal_at\({_V},\s*point\({_A},\s*{_A},\s*{_A}\)\)")
+def step_when_normal_at(context, shape_var, x, y, z):
+    context.n = getattr(context, shape_var).normal_at(Point(parse_math(x), parse_math(y), parse_math(z)))
+
+
+@when(rf"m ← {_V}\.material")
+def step_when_get_material(context, var):
+    context.m = getattr(context, var).material
+
+
+@when(rf"{_V}\.material ← {_V}")
+def step_when_set_material(context, shape_var, mat_var):
+    getattr(context, shape_var).material = getattr(context, mat_var)
+
+
+# ---------------------------------------------------------------------------
+# Then
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V}\.transform = identity_matrix")
+def step_then_transform_is_identity(context, var):
+    assert getattr(context, var).transform == IDENTITY_MATRIX
+
+
+@then(rf"{_V}\.transform = {_V}")
+def step_then_transform_eq_var(context, shape_var, mat_var):
+    assert getattr(context, shape_var).transform == getattr(context, mat_var)
+
+
+@then(rf"xs\.count = {_I}")
+def step_then_xs_count(context, n):
+    assert len(context.xs) == int(n)
+
+
+@then(rf"xs\[{_I}\] = {_A}")
+def step_then_xs_item_t_shorthand(context, idx, val):
+    assert context.xs[int(idx)].t == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"xs\[{_I}\]\.t = {_A}")
+def step_then_xs_item_t(context, idx, val):
+    assert context.xs[int(idx)].t == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"xs\[{_I}\]\.object = {_V}")
+def step_then_xs_item_object(context, idx, obj_var):
+    assert context.xs[int(idx)].object is getattr(context, obj_var)
+
+
+@then(rf"n = vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_n_eq_vector(context, x, y, z):
+    expected = Vector(parse_math(x), parse_math(y), parse_math(z))
+    assert context.n == expected, f"{context.n!r} != vector({x},{y},{z})"
+
+
+@then(r"n = normalize\(n\)")
+def step_then_n_is_normalized(context):
+    n = context.n
+    assert n == Vector(n.x, n.y, n.z).normalize()
+
+
+@then(r"m = material\(\)")
+def step_then_m_is_default_material(context):
+    assert context.m == Material()
+
+
+@then(rf"{_V}\.material = {_V}")
+def step_then_shape_material_eq_var(context, shape_var, mat_var):
+    assert getattr(context, shape_var).material == getattr(context, mat_var)
+
+
+@then(rf"{_V}\.material\.transparency = {_A}")
+def step_then_material_transparency(context, var, val):
+    assert getattr(context, var).material.transparency == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V}\.material\.refractive_index = {_A}")
+def step_then_material_refractive_index(context, var, val):
+    assert getattr(context, var).material.refractive_index == pytest.approx(parse_math(val), abs=1e-5)

--- a/python/rayz/__init__.py
+++ b/python/rayz/__init__.py
@@ -3,8 +3,12 @@ from rayz.canvas import Canvas
 from rayz.color import Color
 from rayz.constants import EPSILON
 from rayz.environment import Environment
+from rayz.intersection import Intersection, hit, intersect, intersections
+from rayz.material import Material
 from rayz.matrix import Matrix
 from rayz.projectile import Projectile
+from rayz.ray import Ray
+from rayz.sphere import Sphere, glass_sphere
 from rayz.tuple import Point, Tuple, Vector
 
 __all__ = [
@@ -12,9 +16,17 @@ __all__ = [
     "Color",
     "EPSILON",
     "Environment",
+    "Intersection",
+    "Material",
     "Matrix",
     "Point",
     "Projectile",
+    "Ray",
+    "Sphere",
     "Tuple",
     "Vector",
+    "glass_sphere",
+    "hit",
+    "intersect",
+    "intersections",
 ]

--- a/python/rayz/intersection.py
+++ b/python/rayz/intersection.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+
+class Intersection:
+    def __init__(self, t: float, obj) -> None:
+        self.t = t
+        self.object = obj
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Intersection):
+            return NotImplemented
+        return self.t == other.t and self.object is other.object
+
+    def __repr__(self) -> str:
+        return f"Intersection(t={self.t}, object={self.object!r})"
+
+
+def intersections(*args: Intersection) -> list[Intersection]:
+    return list(args)
+
+
+def hit(xs: list[Intersection]) -> Intersection | None:
+    valid = [i for i in xs if i.t >= 0]
+    if not valid:
+        return None
+    return min(valid, key=lambda i: i.t)
+
+
+def intersect(shape, ray) -> list[Intersection]:
+    return shape.intersect(ray)

--- a/python/rayz/material.py
+++ b/python/rayz/material.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from rayz.color import Color
+from rayz.constants import EPSILON
+
+
+class Material:
+    def __init__(
+        self,
+        color: Color | None = None,
+        ambient: float = 0.1,
+        diffuse: float = 0.9,
+        specular: float = 0.9,
+        shininess: float = 200.0,
+        reflective: float = 0.0,
+        transparency: float = 0.0,
+        refractive_index: float = 1.0,
+    ) -> None:
+        self.color = color if color is not None else Color(1, 1, 1)
+        self.ambient = ambient
+        self.diffuse = diffuse
+        self.specular = specular
+        self.shininess = shininess
+        self.reflective = reflective
+        self.transparency = transparency
+        self.refractive_index = refractive_index
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Material):
+            return NotImplemented
+        return (
+            self.color == other.color
+            and abs(self.ambient - other.ambient) < EPSILON
+            and abs(self.diffuse - other.diffuse) < EPSILON
+            and abs(self.specular - other.specular) < EPSILON
+            and abs(self.shininess - other.shininess) < EPSILON
+            and abs(self.reflective - other.reflective) < EPSILON
+            and abs(self.transparency - other.transparency) < EPSILON
+            and abs(self.refractive_index - other.refractive_index) < EPSILON
+        )
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __repr__(self) -> str:
+        return (
+            f"Material(color={self.color!r}, ambient={self.ambient}, diffuse={self.diffuse}, "
+            f"specular={self.specular}, shininess={self.shininess})"
+        )

--- a/python/rayz/ray.py
+++ b/python/rayz/ray.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+
+class Ray:
+    def __init__(self, origin, direction) -> None:
+        self.origin = origin
+        self.direction = direction
+
+    def position(self, t: float):
+        return self.origin + self.direction * t
+
+    def transform(self, matrix) -> Ray:
+        return Ray(matrix * self.origin, matrix * self.direction)

--- a/python/rayz/sphere.py
+++ b/python/rayz/sphere.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import math
+
+from rayz.intersection import Intersection
+from rayz.material import Material
+from rayz.matrix import Matrix
+from rayz.tuple import Point, Vector
+
+
+class Sphere:
+    def __init__(self) -> None:
+        self.transform = Matrix.identity(4)
+        self.material = Material()
+
+    def set_transform(self, m: Matrix) -> None:
+        self.transform = m
+
+    def intersect(self, ray) -> list[Intersection]:
+        ray2 = ray.transform(self.transform.inverse())
+        sphere_to_ray = ray2.origin - Point(0, 0, 0)
+        a = ray2.direction.dot(ray2.direction)
+        b = 2 * ray2.direction.dot(sphere_to_ray)
+        c = sphere_to_ray.dot(sphere_to_ray) - 1.0
+        disc = b * b - 4 * a * c
+        if disc < 0:
+            return []
+        t1 = (-b - math.sqrt(disc)) / (2 * a)
+        t2 = (-b + math.sqrt(disc)) / (2 * a)
+        return [Intersection(t1, self), Intersection(t2, self)]
+
+    def normal_at(self, world_point) -> Vector:
+        inv = self.transform.inverse()
+        obj_point = inv * world_point
+        obj_normal = obj_point - Point(0, 0, 0)
+        raw = inv.transpose() * obj_normal
+        return Vector(raw.x, raw.y, raw.z).normalize()
+
+    def __repr__(self) -> str:
+        return f"Sphere(transform={self.transform!r})"
+
+
+def glass_sphere() -> Sphere:
+    s = Sphere()
+    s.material.transparency = 1.0
+    s.material.refractive_index = 1.5
+    return s


### PR DESCRIPTION
## Summary

- Implements `Ray`, `Intersection`, `intersections()`, `hit()`, `Material`, `Sphere`, and `glass_sphere()` in `python/rayz/`
- Adds BDD feature files and step definitions for `rays.feature`, `spheres.feature`, and `intersections.feature` (6 basic hit scenarios)
- Chapter 5 example renders a sphere silhouette (200×200) via ray casting to `examples/chapter5.ppm`
- All 112 scenarios pass, 0 failures; lint clean

## Test plan

- [ ] `cd python && mise exec -- uv run behave` → 112 scenarios passing
- [ ] `mise exec -- uv run python examples/chapter5.py` → produces `chapter5.ppm` with a red sphere silhouette
- [ ] `mise exec -- uv run ruff check .` → no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)