### PR TITLE
Add Python Ch 6: Light and Shading

### DIFF
--- a/python/examples/chapter6.py
+++ b/python/examples/chapter6.py
@@ -1,0 +1,62 @@
+"""Chapter 6: Light and Shading — Phong reflection model."""
+
+from __future__ import annotations
+
+import os
+
+from rayz.canvas import Canvas
+from rayz.color import Color
+from rayz.intersection import hit, intersect
+from rayz.lighting import lighting
+from rayz.point_light import PointLight
+from rayz.ray import Ray
+from rayz.sphere import Sphere
+from rayz.tuple import Point, Vector
+
+
+def run() -> None:
+    print("\n=== Chapter 6: Light and Shading ===\n")
+
+    sphere = Sphere()
+    sphere.material.color = Color(1, 0.2, 1)
+
+    light = PointLight(Point(-10, 10, -10), Color(1, 1, 1))
+
+    canvas_size = 200
+    canvas = Canvas(canvas_size, canvas_size)
+
+    ray_origin = Point(0, 0, -5)
+    wall_z = 10.0
+    wall_size = 7.0
+    pixel_size = wall_size / canvas_size
+    half = wall_size / 2.0
+
+    print(f"Rendering {canvas_size}x{canvas_size} Phong-shaded sphere...")
+    for row in range(canvas_size):
+        world_y = half - pixel_size * row
+        for col in range(canvas_size):
+            world_x = -half + pixel_size * col
+            target = Point(world_x, world_y, wall_z)
+            diff = target - ray_origin
+            direction = Vector(diff.x, diff.y, diff.z).normalize()
+            r = Ray(ray_origin, direction)
+            xs = intersect(sphere, r)
+            h = hit(xs)
+            if h is not None:
+                point = r.position(h.t)
+                normal = h.object.normal_at(point)
+                eye = -r.direction
+                color = lighting(h.object.material, light, point, eye, normal)
+                canvas.write_pixel(col=col, row=row, color=color)
+
+    out_path = os.path.join(os.path.dirname(__file__), "chapter6.ppm")
+    print(f"Writing {out_path}...", end="", flush=True)
+    with open(out_path, "w") as f:
+        f.write(canvas.to_ppm())
+    print(" done.")
+    print("Shaded sphere with Phong lighting rendered.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/examples/run.py
+++ b/python/examples/run.py
@@ -14,6 +14,7 @@ from examples.chapter2 import run as ch2
 from examples.chapter3 import run as ch3
 from examples.chapter4 import run as ch4
 from examples.chapter5 import run as ch5
+from examples.chapter6 import run as ch6
 
 CHAPTERS: dict[int, tuple[str, object]] = {
     1: ("Projectile physics", ch1),
@@ -21,6 +22,7 @@ CHAPTERS: dict[int, tuple[str, object]] = {
     3: ("Matrices", ch3),
     4: ("Transformations", ch4),
     5: ("Ray-sphere intersections", ch5),
+    6: ("Light and Shading", ch6),
 }
 
 

--- a/python/features/lights.feature
+++ b/python/features/lights.feature
@@ -1,0 +1,8 @@
+Feature: Lights
+
+Scenario: A point light has a position and intensity
+  Given intensity ← color(1, 1, 1)
+    And position ← point(0, 0, 0)
+  When light ← point_light(position, intensity)
+  Then light.position = position
+    And light.intensity = intensity

--- a/python/features/materials.feature
+++ b/python/features/materials.feature
@@ -1,0 +1,78 @@
+Feature: Materials
+
+Background:
+  Given m ← material()
+    And position ← point(0, 0, 0)
+
+Scenario: The default material
+  Given m ← material()
+  Then m.color = color(1, 1, 1)
+    And m.ambient = 0.1
+    And m.diffuse = 0.9
+    And m.specular = 0.9
+    And m.shininess = 200.0
+
+Scenario: Reflectivity for the default material
+  Given m ← material()
+  Then m.reflective = 0.0
+
+Scenario: Transparency and Refractive Index for the default material
+  Given m ← material()
+  Then m.transparency = 0.0
+    And m.refractive_index = 1.0
+
+Scenario: Lighting with the eye between the light and the surface
+  Given eyev ← vector(0, 0, -1)
+    And normalv ← vector(0, 0, -1)
+    And light ← point_light(point(0, 0, -10), color(1, 1, 1))
+  When result ← lighting(m, light, position, eyev, normalv)
+  Then result = color(1.9, 1.9, 1.9)
+
+Scenario: Lighting with the eye between light and surface, eye offset 45°
+  Given eyev ← vector(0, √2/2, -√2/2)
+    And normalv ← vector(0, 0, -1)
+    And light ← point_light(point(0, 0, -10), color(1, 1, 1))
+  When result ← lighting(m, light, position, eyev, normalv)
+  Then result = color(1.0, 1.0, 1.0)
+
+Scenario: Lighting with eye opposite surface, light offset 45°
+  Given eyev ← vector(0, 0, -1)
+    And normalv ← vector(0, 0, -1)
+    And light ← point_light(point(0, 10, -10), color(1, 1, 1))
+  When result ← lighting(m, light, position, eyev, normalv)
+  Then result = color(0.7364, 0.7364, 0.7364)
+
+Scenario: Lighting with eye in the path of the reflection vector
+  Given eyev ← vector(0, -√2/2, -√2/2)
+    And normalv ← vector(0, 0, -1)
+    And light ← point_light(point(0, 10, -10), color(1, 1, 1))
+  When result ← lighting(m, light, position, eyev, normalv)
+  Then result = color(1.6364, 1.6364, 1.6364)
+
+Scenario: Lighting with the light behind the surface
+  Given eyev ← vector(0, 0, -1)
+    And normalv ← vector(0, 0, -1)
+    And light ← point_light(point(0, 0, 10), color(1, 1, 1))
+  When result ← lighting(m, light, position, eyev, normalv)
+  Then result = color(0.1, 0.1, 0.1)
+
+Scenario: Lighting with the surface in shadow
+  Given eyev ← vector(0, 0, -1)
+    And normalv ← vector(0, 0, -1)
+    And light ← point_light(point(0, 0, -10), color(1, 1, 1))
+    And in_shadow ← true
+  When result ← lighting(m, light, position, eyev, normalv, in_shadow)
+  Then result = color(0.1, 0.1, 0.1)
+
+Scenario: Lighting with a pattern applied
+  Given m.pattern ← stripe_pattern(color(1, 1, 1), color(0, 0, 0))
+    And m.ambient ← 1
+    And m.diffuse ← 0
+    And m.specular ← 0
+    And eyev ← vector(0, 0, -1)
+    And normalv ← vector(0, 0, -1)
+    And light ← point_light(point(0, 0, -10), color(1, 1, 1))
+  When c1 ← lighting(m, light, point(0.9, 0, 0), eyev, normalv, false)
+    And c2 ← lighting(m, light, point(1.1, 0, 0), eyev, normalv, false)
+  Then c1 = color(1, 1, 1)
+    And c2 = color(0, 0, 0)

--- a/python/features/shapes.feature
+++ b/python/features/shapes.feature
@@ -1,0 +1,55 @@
+Feature: Abstract Shapes
+
+Scenario: The default transformation
+  Given s ← test_shape()
+  Then s.transform = identity_matrix
+
+Scenario: Assigning a transformation
+  Given s ← test_shape()
+  When set_transform(s, translation(2, 3, 4))
+  Then s.transform = translation(2, 3, 4)
+
+Scenario: The default material
+  Given s ← test_shape()
+  When m ← s.material
+  Then m = material()
+
+Scenario: Assigning a material
+  Given s ← test_shape()
+    And m ← material()
+    And m.ambient ← 1
+  When s.material ← m
+  Then s.material = m
+
+Scenario: Intersecting a scaled shape with a ray
+  Given r ← ray(point(0, 0, -5), vector(0, 0, 1))
+    And s ← test_shape()
+  When set_transform(s, scaling(2, 2, 2))
+    And xs ← intersect(s, r)
+  Then s.saved_ray.origin = point(0, 0, -2.5)
+    And s.saved_ray.direction = vector(0, 0, 0.5)
+
+Scenario: Intersecting a translated shape with a ray
+  Given r ← ray(point(0, 0, -5), vector(0, 0, 1))
+    And s ← test_shape()
+  When set_transform(s, translation(5, 0, 0))
+    And xs ← intersect(s, r)
+  Then s.saved_ray.origin = point(-5, 0, -5)
+    And s.saved_ray.direction = vector(0, 0, 1)
+
+Scenario: Computing the normal on a translated shape
+  Given s ← test_shape()
+  When set_transform(s, translation(0, 1, 0))
+    And n ← normal_at(s, point(0, 1.70711, -0.70711))
+  Then n = vector(0, 0.70711, -0.70711)
+
+Scenario: Computing the normal on a transformed shape
+  Given s ← test_shape()
+    And m ← scaling(1, 0.5, 1) * rotation_z(π/5)
+  When set_transform(s, m)
+    And n ← normal_at(s, point(0, √2/2, -√2/2))
+  Then n = vector(0, 0.97014, -0.24254)
+
+Scenario: A shape has a parent attribute
+  Given s ← test_shape()
+  Then s.parent is nothing

--- a/python/features/steps/lights.py
+++ b/python/features/steps/lights.py
@@ -1,0 +1,32 @@
+from behave import given, then, use_step_matcher, when
+
+from rayz.point_light import PointLight
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+
+
+def _make_point_light(context, var, pos_var, int_var):
+    setattr(context, var, PointLight(getattr(context, pos_var), getattr(context, int_var)))
+
+
+@given(rf"{_V} ← point_light\({_V},\s*{_V}\)")
+def step_given_point_light_vars(context, var, pos_var, int_var):
+    _make_point_light(context, var, pos_var, int_var)
+
+
+@when(rf"{_V} ← point_light\({_V},\s*{_V}\)")
+def step_when_point_light_vars(context, var, pos_var, int_var):
+    _make_point_light(context, var, pos_var, int_var)
+
+
+@then(rf"{_V}\.position = {_V}")
+def step_then_light_position(context, light_var, pos_var):
+    assert getattr(context, light_var).position == getattr(context, pos_var)
+
+
+@then(rf"{_V}\.intensity = {_V}")
+def step_then_light_intensity(context, light_var, int_var):
+    assert getattr(context, light_var).intensity == getattr(context, int_var)

--- a/python/features/steps/materials.py
+++ b/python/features/steps/materials.py
@@ -49,9 +49,7 @@ def step_given_true(context, var):
     setattr(context, var, True)
 
 
-@when(
-    rf"{_V} ← lighting\({_V},\s*{_V},\s*{_V},\s*{_V},\s*{_V}\)"
-)
+@when(rf"{_V} ← lighting\({_V},\s*{_V},\s*{_V},\s*{_V},\s*{_V}\)")
 def step_when_lighting_no_shadow(context, result, mat, light, pos, eyev, normalv):
     setattr(
         context,
@@ -66,9 +64,7 @@ def step_when_lighting_no_shadow(context, result, mat, light, pos, eyev, normalv
     )
 
 
-@when(
-    rf"{_V} ← lighting\({_V},\s*{_V},\s*{_V},\s*{_V},\s*{_V},\s*{_V}\)"
-)
+@when(rf"{_V} ← lighting\({_V},\s*{_V},\s*{_V},\s*{_V},\s*{_V},\s*{_V}\)")
 def step_when_lighting_with_shadow(context, result, mat, light, pos, eyev, normalv, shadow):
     shadow_val = getattr(context, shadow) if hasattr(context, shadow) else (shadow == "true")
     setattr(
@@ -85,9 +81,7 @@ def step_when_lighting_with_shadow(context, result, mat, light, pos, eyev, norma
     )
 
 
-@when(
-    rf"{_V} ← lighting\({_V},\s*{_V},\s*point\({_A},\s*{_A},\s*{_A}\),\s*{_V},\s*{_V},\s*(false|true)\)"
-)
+@when(rf"{_V} ← lighting\({_V},\s*{_V},\s*point\({_A},\s*{_A},\s*{_A}\),\s*{_V},\s*{_V},\s*(false|true)\)")
 def step_when_lighting_inline_point(context, result, mat, light, px, py, pz, eyev, normalv, shadow):
     setattr(
         context,

--- a/python/features/steps/materials.py
+++ b/python/features/steps/materials.py
@@ -1,0 +1,144 @@
+import pytest
+from behave import given, then, use_step_matcher, when
+
+from rayz.color import Color
+from rayz.lighting import lighting
+from rayz.math_parser import parse_math
+from rayz.pattern import stripe_pattern
+from rayz.point_light import PointLight
+from rayz.tuple import Point
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+
+
+@given(rf"{_V} ← point_light\(point\({_A},\s*{_A},\s*{_A}\),\s*color\({_A},\s*{_A},\s*{_A}\)\)")
+def step_given_point_light_inline(context, var, px, py, pz, ir, ig, ib):
+    setattr(
+        context,
+        var,
+        PointLight(
+            Point(parse_math(px), parse_math(py), parse_math(pz)),
+            Color(parse_math(ir), parse_math(ig), parse_math(ib)),
+        ),
+    )
+
+
+@given(rf"{_V}\.diffuse ← {_A}")
+def step_given_set_diffuse(context, var, val):
+    getattr(context, var).diffuse = parse_math(val)
+
+
+@given(rf"{_V}\.specular ← {_A}")
+def step_given_set_specular(context, var, val):
+    getattr(context, var).specular = parse_math(val)
+
+
+@given(rf"{_V}\.pattern ← stripe_pattern\(color\({_A},\s*{_A},\s*{_A}\),\s*color\({_A},\s*{_A},\s*{_A}\)\)")
+def step_given_set_pattern(context, var, r1, g1, b1, r2, g2, b2):
+    getattr(context, var).pattern = stripe_pattern(
+        Color(parse_math(r1), parse_math(g1), parse_math(b1)),
+        Color(parse_math(r2), parse_math(g2), parse_math(b2)),
+    )
+
+
+@given(rf"{_V} ← true")
+def step_given_true(context, var):
+    setattr(context, var, True)
+
+
+@when(
+    rf"{_V} ← lighting\({_V},\s*{_V},\s*{_V},\s*{_V},\s*{_V}\)"
+)
+def step_when_lighting_no_shadow(context, result, mat, light, pos, eyev, normalv):
+    setattr(
+        context,
+        result,
+        lighting(
+            getattr(context, mat),
+            getattr(context, light),
+            getattr(context, pos),
+            getattr(context, eyev),
+            getattr(context, normalv),
+        ),
+    )
+
+
+@when(
+    rf"{_V} ← lighting\({_V},\s*{_V},\s*{_V},\s*{_V},\s*{_V},\s*{_V}\)"
+)
+def step_when_lighting_with_shadow(context, result, mat, light, pos, eyev, normalv, shadow):
+    shadow_val = getattr(context, shadow) if hasattr(context, shadow) else (shadow == "true")
+    setattr(
+        context,
+        result,
+        lighting(
+            getattr(context, mat),
+            getattr(context, light),
+            getattr(context, pos),
+            getattr(context, eyev),
+            getattr(context, normalv),
+            shadow_val,
+        ),
+    )
+
+
+@when(
+    rf"{_V} ← lighting\({_V},\s*{_V},\s*point\({_A},\s*{_A},\s*{_A}\),\s*{_V},\s*{_V},\s*(false|true)\)"
+)
+def step_when_lighting_inline_point(context, result, mat, light, px, py, pz, eyev, normalv, shadow):
+    setattr(
+        context,
+        result,
+        lighting(
+            getattr(context, mat),
+            getattr(context, light),
+            Point(parse_math(px), parse_math(py), parse_math(pz)),
+            getattr(context, eyev),
+            getattr(context, normalv),
+            shadow == "true",
+        ),
+    )
+
+
+@then(rf"{_V}\.color = color\({_A},\s*{_A},\s*{_A}\)")
+def step_then_material_color(context, var, r, g, b):
+    expected = Color(parse_math(r), parse_math(g), parse_math(b))
+    assert getattr(context, var).color == expected
+
+
+@then(rf"{_V}\.ambient = {_A}")
+def step_then_material_ambient(context, var, val):
+    assert getattr(context, var).ambient == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V}\.diffuse = {_A}")
+def step_then_material_diffuse(context, var, val):
+    assert getattr(context, var).diffuse == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V}\.specular = {_A}")
+def step_then_material_specular(context, var, val):
+    assert getattr(context, var).specular == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V}\.shininess = {_A}")
+def step_then_material_shininess(context, var, val):
+    assert getattr(context, var).shininess == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V}\.reflective = {_A}")
+def step_then_material_reflective(context, var, val):
+    assert getattr(context, var).reflective == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V}\.transparency = {_A}")
+def step_then_material_transparency(context, var, val):
+    assert getattr(context, var).transparency == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V}\.refractive_index = {_A}")
+def step_then_material_refractive_index(context, var, val):
+    assert getattr(context, var).refractive_index == pytest.approx(parse_math(val), abs=1e-5)

--- a/python/features/steps/shapes.py
+++ b/python/features/steps/shapes.py
@@ -30,6 +30,7 @@ _TRANSFORM_FUNCS = {
 
 def _eval_transform(context, expr: str) -> Matrix:
     import re
+
     expr = expr.strip()
     m = re.fullmatch(r"(scaling|translation|rotation_x|rotation_y|rotation_z)\((.+)\)", expr)
     if m:

--- a/python/features/steps/shapes.py
+++ b/python/features/steps/shapes.py
@@ -1,0 +1,76 @@
+from behave import given, then, use_step_matcher
+
+from rayz.math_parser import parse_math
+from rayz.matrix import Matrix
+from rayz.shape import TestShape
+from rayz.transformations import (
+    rotation_x,
+    rotation_y,
+    rotation_z,
+    scaling,
+    translation,
+)
+from rayz.tuple import Point, Vector
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+
+IDENTITY_MATRIX = Matrix.identity(4)
+
+_TRANSFORM_FUNCS = {
+    "scaling": scaling,
+    "translation": translation,
+    "rotation_x": rotation_x,
+    "rotation_y": rotation_y,
+    "rotation_z": rotation_z,
+}
+
+
+def _eval_transform(context, expr: str) -> Matrix:
+    import re
+    expr = expr.strip()
+    m = re.fullmatch(r"(scaling|translation|rotation_x|rotation_y|rotation_z)\((.+)\)", expr)
+    if m:
+        func = _TRANSFORM_FUNCS[m.group(1)]
+        args = [parse_math(a.strip()) for a in m.group(2).split(",")]
+        return func(*args)
+    return getattr(context, expr)
+
+
+@given(rf"{_V} ← test_shape\(\)")
+def step_given_test_shape(context, var):
+    setattr(context, var, TestShape())
+
+
+@then(rf"{_V}\.transform = identity_matrix")
+def step_then_shape_transform_identity(context, var):
+    assert getattr(context, var).transform == IDENTITY_MATRIX
+
+
+@then(rf"{_V}\.transform = {_V}")
+def step_then_shape_transform_eq_var(context, shape_var, mat_var):
+    assert getattr(context, shape_var).transform == getattr(context, mat_var)
+
+
+@then(rf"{_V}\.transform = translation\({_A},\s*{_A},\s*{_A}\)")
+def step_then_shape_transform_eq_translation(context, var, x, y, z):
+    assert getattr(context, var).transform == translation(parse_math(x), parse_math(y), parse_math(z))
+
+
+@then(rf"{_V}\.saved_ray\.origin = point\({_A},\s*{_A},\s*{_A}\)")
+def step_then_saved_ray_origin(context, var, x, y, z):
+    expected = Point(parse_math(x), parse_math(y), parse_math(z))
+    assert getattr(context, var).saved_ray.origin == expected
+
+
+@then(rf"{_V}\.saved_ray\.direction = vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_saved_ray_direction(context, var, x, y, z):
+    expected = Vector(parse_math(x), parse_math(y), parse_math(z))
+    assert getattr(context, var).saved_ray.direction == expected
+
+
+@then(rf"{_V}\.parent is nothing")
+def step_then_parent_is_nothing(context, var):
+    assert getattr(context, var).parent is None

--- a/python/rayz/lighting.py
+++ b/python/rayz/lighting.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from rayz.color import Color
+
+
+def lighting(material, light, point, eyev, normalv, in_shadow=False, obj=None) -> Color:
+    if material.pattern is not None:
+        if obj is not None:
+            color = material.pattern.pattern_at_shape(obj, point)
+        else:
+            color = material.pattern.pattern_at(point)
+    else:
+        color = material.color
+
+    effective_color = color * light.intensity
+    ambient = effective_color * material.ambient
+
+    if in_shadow:
+        return ambient
+
+    lightv = (light.position - point).normalize()
+    light_dot_normal = lightv.dot(normalv)
+
+    if light_dot_normal < 0:
+        return ambient
+
+    diffuse = effective_color * material.diffuse * light_dot_normal
+
+    reflectv = (-lightv).reflect(normalv)
+    reflect_dot_eye = reflectv.dot(eyev)
+
+    if reflect_dot_eye <= 0:
+        return ambient + diffuse
+
+    factor = reflect_dot_eye**material.shininess
+    specular = light.intensity * material.specular * factor
+    return ambient + diffuse + specular

--- a/python/rayz/material.py
+++ b/python/rayz/material.py
@@ -24,6 +24,7 @@ class Material:
         self.reflective = reflective
         self.transparency = transparency
         self.refractive_index = refractive_index
+        self.pattern = None
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Material):

--- a/python/rayz/pattern.py
+++ b/python/rayz/pattern.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import math
+
+from rayz.color import Color
+
+
+class StripePattern:
+    def __init__(self, a: Color, b: Color) -> None:
+        self.a = a
+        self.b = b
+
+    def pattern_at(self, point) -> Color:
+        return self.a if int(math.floor(point.x)) % 2 == 0 else self.b
+
+    def pattern_at_shape(self, shape, world_point) -> Color:
+        return self.pattern_at(world_point)
+
+
+def stripe_pattern(a: Color, b: Color) -> StripePattern:
+    return StripePattern(a, b)

--- a/python/rayz/point_light.py
+++ b/python/rayz/point_light.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from rayz.color import Color
+from rayz.tuple import Point
+
+
+class PointLight:
+    def __init__(self, position: Point, intensity: Color) -> None:
+        self.position = position
+        self.intensity = intensity
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, PointLight):
+            return NotImplemented
+        return self.position == other.position and self.intensity == other.intensity
+
+    def __repr__(self) -> str:
+        return f"PointLight(position={self.position!r}, intensity={self.intensity!r})"

--- a/python/rayz/shape.py
+++ b/python/rayz/shape.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from rayz.material import Material
+from rayz.matrix import Matrix
+from rayz.tuple import Vector
+
+
+class Shape(ABC):
+    def __init__(self) -> None:
+        self.transform = Matrix.identity(4)
+        self.material = Material()
+        self.parent = None
+
+    def set_transform(self, m: Matrix) -> None:
+        self.transform = m
+
+    def intersect(self, ray) -> list:
+        local_ray = ray.transform(self.transform.inverse())
+        return self.local_intersect(local_ray)
+
+    def normal_at(self, world_point) -> Vector:
+        inv = self.transform.inverse()
+        local_point = inv * world_point
+        local_normal = self.local_normal_at(local_point)
+        world_normal = inv.transpose() * local_normal
+        return Vector(world_normal.x, world_normal.y, world_normal.z).normalize()
+
+    @abstractmethod
+    def local_intersect(self, ray) -> list:
+        ...
+
+    @abstractmethod
+    def local_normal_at(self, point) -> Vector:
+        ...
+
+
+class TestShape(Shape):
+    def __init__(self) -> None:
+        super().__init__()
+        self.saved_ray = None
+
+    def local_intersect(self, ray) -> list:
+        self.saved_ray = ray
+        return []
+
+    def local_normal_at(self, point) -> Vector:
+        return Vector(point.x, point.y, point.z)

--- a/python/rayz/shape.py
+++ b/python/rayz/shape.py
@@ -28,12 +28,10 @@ class Shape(ABC):
         return Vector(world_normal.x, world_normal.y, world_normal.z).normalize()
 
     @abstractmethod
-    def local_intersect(self, ray) -> list:
-        ...
+    def local_intersect(self, ray) -> list: ...
 
     @abstractmethod
-    def local_normal_at(self, point) -> Vector:
-        ...
+    def local_normal_at(self, point) -> Vector: ...
 
 
 class TestShape(Shape):


### PR DESCRIPTION
## Summary

- Add `PointLight` class for point light sources
- Add Phong lighting function (`lighting()`) implementing ambient + diffuse + specular model with shadow support
- Add abstract `Shape` base class with `TestShape` for BDD testing
- Add minimal `StripePattern` for the materials.feature pattern scenario
- Add BDD features: `lights.feature`, `materials.feature`, `shapes.feature` (20 new scenarios)
- Add `chapter6.py` example rendering a Phong-shaded sphere

## Test plan

- [x] All 132 BDD scenarios pass (`mise exec -- uv run behave`)
- [x] `ruff check` passes with no errors
- [x] Chapter 6 example runs and produces `chapter6.ppm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)