### PR TITLE
Add Python Ch 6a: Patterns

### DIFF
--- a/python/features/patterns.feature
+++ b/python/features/patterns.feature
@@ -1,0 +1,117 @@
+Feature: Patterns
+
+Background:
+  Given black ← color(0, 0, 0)
+    And white ← color(1, 1, 1)
+
+Scenario: Creating a stripe pattern
+  Given pattern ← stripe_pattern(white, black)
+  Then pattern.a = white
+    And pattern.b = black
+
+Scenario: A stripe pattern is constant in y
+  Given pattern ← stripe_pattern(white, black)
+  Then stripe_at(pattern, point(0, 0, 0)) = white
+    And stripe_at(pattern, point(0, 1, 0)) = white
+    And stripe_at(pattern, point(0, 2, 0)) = white
+
+Scenario: A stripe pattern is constant in z
+  Given pattern ← stripe_pattern(white, black)
+  Then stripe_at(pattern, point(0, 0, 0)) = white
+    And stripe_at(pattern, point(0, 0, 1)) = white
+    And stripe_at(pattern, point(0, 0, 2)) = white
+
+Scenario: A stripe pattern alternates in x
+  Given pattern ← stripe_pattern(white, black)
+  Then stripe_at(pattern, point(0, 0, 0)) = white
+    And stripe_at(pattern, point(0.9, 0, 0)) = white
+    And stripe_at(pattern, point(1, 0, 0)) = black
+    And stripe_at(pattern, point(-0.1, 0, 0)) = black
+    And stripe_at(pattern, point(-1, 0, 0)) = black
+    And stripe_at(pattern, point(-1.1, 0, 0)) = white
+
+Scenario: Stripes with an object transformation
+  Given object ← sphere()
+    And set_transform(object, scaling(2, 2, 2))
+    And pattern ← stripe_pattern(white, black)
+  When c ← stripe_at_object(pattern, object, point(1.5, 0, 0))
+  Then c = white
+
+Scenario: Stripes with a pattern transformation
+  Given object ← sphere()
+    And pattern ← stripe_pattern(white, black)
+    And set_pattern_transform(pattern, scaling(2, 2, 2))
+  When c ← stripe_at_object(pattern, object, point(1.5, 0, 0))
+  Then c = white
+
+Scenario: Stripes with both an object and a pattern transformation
+  Given object ← sphere()
+    And set_transform(object, scaling(2, 2, 2))
+    And pattern ← stripe_pattern(white, black)
+    And set_pattern_transform(pattern, translation(0.5, 0, 0))
+  When c ← stripe_at_object(pattern, object, point(2.5, 0, 0))
+  Then c = white
+
+Scenario: The default pattern transformation
+  Given pattern ← test_pattern()
+  Then pattern.transform = identity_matrix
+
+Scenario: Assigning a transformation
+  Given pattern ← test_pattern()
+  When set_pattern_transform(pattern, translation(1, 2, 3))
+  Then pattern.transform = translation(1, 2, 3)
+
+Scenario: A pattern with an object transformation
+  Given shape ← sphere()
+    And set_transform(shape, scaling(2, 2, 2))
+    And pattern ← test_pattern()
+  When c ← pattern_at_shape(pattern, shape, point(2, 3, 4))
+  Then c = color(1, 1.5, 2)
+
+Scenario: A pattern with a pattern transformation
+  Given shape ← sphere()
+    And pattern ← test_pattern()
+    And set_pattern_transform(pattern, scaling(2, 2, 2))
+  When c ← pattern_at_shape(pattern, shape, point(2, 3, 4))
+  Then c = color(1, 1.5, 2)
+
+Scenario: A pattern with both an object and a pattern transformation
+  Given shape ← sphere()
+    And set_transform(shape, scaling(2, 2, 2))
+    And pattern ← test_pattern()
+    And set_pattern_transform(pattern, translation(0.5, 1, 1.5))
+  When c ← pattern_at_shape(pattern, shape, point(2.5, 3, 3.5))
+  Then c = color(0.75, 0.5, 0.25)
+
+Scenario: A gradient linearly interpolates between colors
+  Given pattern ← gradient_pattern(white, black)
+  Then pattern_at(pattern, point(0, 0, 0)) = white
+    And pattern_at(pattern, point(0.25, 0, 0)) = color(0.75, 0.75, 0.75)
+    And pattern_at(pattern, point(0.5, 0, 0)) = color(0.5, 0.5, 0.5)
+    And pattern_at(pattern, point(0.75, 0, 0)) = color(0.25, 0.25, 0.25)
+
+Scenario: A ring should extend in both x and z
+  Given pattern ← ring_pattern(white, black)
+  Then pattern_at(pattern, point(0, 0, 0)) = white
+    And pattern_at(pattern, point(1, 0, 0)) = black
+    And pattern_at(pattern, point(0, 0, 1)) = black
+    # 0.708 = just slightly more than √2/2
+    And pattern_at(pattern, point(0.708, 0, 0.708)) = black
+
+Scenario: Checkers should repeat in x
+  Given pattern ← checkers_pattern(white, black)
+  Then pattern_at(pattern, point(0, 0, 0)) = white
+    And pattern_at(pattern, point(0.99, 0, 0)) = white
+    And pattern_at(pattern, point(1.01, 0, 0)) = black
+
+Scenario: Checkers should repeat in y
+  Given pattern ← checkers_pattern(white, black)
+  Then pattern_at(pattern, point(0, 0, 0)) = white
+    And pattern_at(pattern, point(0, 0.99, 0)) = white
+    And pattern_at(pattern, point(0, 1.01, 0)) = black
+
+Scenario: Checkers should repeat in z
+  Given pattern ← checkers_pattern(white, black)
+  Then pattern_at(pattern, point(0, 0, 0)) = white
+    And pattern_at(pattern, point(0, 0, 0.99)) = white
+    And pattern_at(pattern, point(0, 0, 1.01)) = black

--- a/python/features/steps/patterns.py
+++ b/python/features/steps/patterns.py
@@ -1,0 +1,150 @@
+from behave import given, then, use_step_matcher, when
+
+from rayz.color import Color
+from rayz.math_parser import parse_math
+from rayz.matrix import Matrix
+from rayz.pattern import (
+    checkers_pattern,
+    gradient_pattern,
+    ring_pattern,
+    stripe_pattern,
+    test_pattern,
+)
+from rayz.transformations import scaling, translation
+from rayz.tuple import Point
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+
+IDENTITY_MATRIX = Matrix.identity(4)
+
+_TRANSFORM_MAP = {"scaling": scaling, "translation": translation}
+
+
+def _eval_transform(expr: str):
+    import re
+
+    m = re.fullmatch(r"(scaling|translation)\((.+)\)", expr.strip())
+    if m:
+        args = [parse_math(a.strip()) for a in m.group(2).split(",")]
+        return _TRANSFORM_MAP[m.group(1)](*args)
+    raise ValueError(f"Unknown transform: {expr!r}")
+
+
+# ---------------------------------------------------------------------------
+# Given
+# ---------------------------------------------------------------------------
+
+
+@given(rf"{_V} ← stripe_pattern\({_V},\s*{_V}\)")
+def step_given_stripe_pattern(context, var, a_var, b_var):
+    setattr(context, var, stripe_pattern(getattr(context, a_var), getattr(context, b_var)))
+
+
+@given(rf"{_V} ← gradient_pattern\({_V},\s*{_V}\)")
+def step_given_gradient_pattern(context, var, a_var, b_var):
+    setattr(context, var, gradient_pattern(getattr(context, a_var), getattr(context, b_var)))
+
+
+@given(rf"{_V} ← ring_pattern\({_V},\s*{_V}\)")
+def step_given_ring_pattern(context, var, a_var, b_var):
+    setattr(context, var, ring_pattern(getattr(context, a_var), getattr(context, b_var)))
+
+
+@given(rf"{_V} ← checkers_pattern\({_V},\s*{_V}\)")
+def step_given_checkers_pattern(context, var, a_var, b_var):
+    setattr(context, var, checkers_pattern(getattr(context, a_var), getattr(context, b_var)))
+
+
+@given(rf"{_V} ← test_pattern\(\)")
+def step_given_test_pattern(context, var):
+    setattr(context, var, test_pattern())
+
+
+@given(rf"set_pattern_transform\({_V},\s*(.+)\)")
+def step_given_set_pattern_transform(context, var, expr):
+    getattr(context, var).set_transform(_eval_transform(expr))
+
+
+# ---------------------------------------------------------------------------
+# When
+# ---------------------------------------------------------------------------
+
+
+@when(rf"set_pattern_transform\({_V},\s*(.+)\)")
+def step_when_set_pattern_transform(context, var, expr):
+    getattr(context, var).set_transform(_eval_transform(expr))
+
+
+@when(rf"c ← stripe_at_object\({_V},\s*{_V},\s*point\({_A},\s*{_A},\s*{_A}\)\)")
+def step_when_stripe_at_object(context, pat_var, obj_var, x, y, z):
+    pat = getattr(context, pat_var)
+    obj = getattr(context, obj_var)
+    context.c = pat.pattern_at_shape(obj, Point(parse_math(x), parse_math(y), parse_math(z)))
+
+
+@when(rf"c ← pattern_at_shape\({_V},\s*{_V},\s*point\({_A},\s*{_A},\s*{_A}\)\)")
+def step_when_pattern_at_shape(context, pat_var, shape_var, x, y, z):
+    pat = getattr(context, pat_var)
+    shape = getattr(context, shape_var)
+    context.c = pat.pattern_at_shape(shape, Point(parse_math(x), parse_math(y), parse_math(z)))
+
+
+# ---------------------------------------------------------------------------
+# Then
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V}\.a = {_V}")
+def step_then_pattern_a(context, pat_var, color_var):
+    assert getattr(context, pat_var).a == getattr(context, color_var)
+
+
+@then(rf"{_V}\.b = {_V}")
+def step_then_pattern_b(context, pat_var, color_var):
+    assert getattr(context, pat_var).b == getattr(context, color_var)
+
+
+@then(rf"stripe_at\({_V},\s*point\({_A},\s*{_A},\s*{_A}\)\) = {_V}")
+def step_then_stripe_at_eq_var(context, pat_var, x, y, z, color_var):
+    pat = getattr(context, pat_var)
+    result = pat.pattern_at(Point(parse_math(x), parse_math(y), parse_math(z)))
+    assert result == getattr(context, color_var)
+
+
+@then(rf"pattern_at\({_V},\s*point\({_A},\s*{_A},\s*{_A}\)\) = {_V}")
+def step_then_pattern_at_eq_var(context, pat_var, x, y, z, color_var):
+    pat = getattr(context, pat_var)
+    result = pat.pattern_at(Point(parse_math(x), parse_math(y), parse_math(z)))
+    assert result == getattr(context, color_var)
+
+
+@then(rf"pattern_at\({_V},\s*point\({_A},\s*{_A},\s*{_A}\)\) = color\({_A},\s*{_A},\s*{_A}\)")
+def step_then_pattern_at_eq_color(context, pat_var, px, py, pz, cr, cg, cb):
+    pat = getattr(context, pat_var)
+    result = pat.pattern_at(Point(parse_math(px), parse_math(py), parse_math(pz)))
+    expected = Color(parse_math(cr), parse_math(cg), parse_math(cb))
+    assert result == expected, f"{result!r} != {expected!r}"
+
+
+@then(rf"{_V}\.transform = identity_matrix")
+def step_then_pattern_transform_identity(context, var):
+    assert getattr(context, var).transform == IDENTITY_MATRIX
+
+
+@then(rf"{_V}\.transform = translation\({_A},\s*{_A},\s*{_A}\)")
+def step_then_pattern_transform_translation(context, var, x, y, z):
+    assert getattr(context, var).transform == translation(parse_math(x), parse_math(y), parse_math(z))
+
+
+@then(rf"c = {_V}")
+def step_then_c_eq_var(context, color_var):
+    assert context.c == getattr(context, color_var)
+
+
+@then(rf"c = color\({_A},\s*{_A},\s*{_A}\)")
+def step_then_c_eq_color(context, r, g, b):
+    expected = Color(parse_math(r), parse_math(g), parse_math(b))
+    assert context.c == expected, f"{context.c!r} != {expected!r}"

--- a/python/rayz/pattern.py
+++ b/python/rayz/pattern.py
@@ -1,21 +1,94 @@
 from __future__ import annotations
 
 import math
+from abc import ABC, abstractmethod
 
 from rayz.color import Color
+from rayz.matrix import Matrix
 
 
-class StripePattern:
+class Pattern(ABC):
+    def __init__(self) -> None:
+        self.transform = Matrix.identity(4)
+
+    def set_transform(self, m: Matrix) -> None:
+        self.transform = m
+
+    @abstractmethod
+    def pattern_at(self, point) -> Color: ...
+
+    def pattern_at_shape(self, shape, world_point) -> Color:
+        inv_shape = shape.transform.inverse()
+        object_point = inv_shape * world_point
+        inv_pattern = self.transform.inverse()
+        pattern_point = inv_pattern * object_point
+        return self.pattern_at(pattern_point)
+
+
+class StripePattern(Pattern):
     def __init__(self, a: Color, b: Color) -> None:
+        super().__init__()
         self.a = a
         self.b = b
 
     def pattern_at(self, point) -> Color:
         return self.a if int(math.floor(point.x)) % 2 == 0 else self.b
 
-    def pattern_at_shape(self, shape, world_point) -> Color:
-        return self.pattern_at(world_point)
+
+class GradientPattern(Pattern):
+    def __init__(self, a: Color, b: Color) -> None:
+        super().__init__()
+        self.a = a
+        self.b = b
+
+    def pattern_at(self, point) -> Color:
+        distance = self.b - self.a
+        fraction = point.x - math.floor(point.x)
+        return self.a + distance * fraction
+
+
+class RingPattern(Pattern):
+    def __init__(self, a: Color, b: Color) -> None:
+        super().__init__()
+        self.a = a
+        self.b = b
+
+    def pattern_at(self, point) -> Color:
+        distance = math.sqrt(point.x**2 + point.z**2)
+        return self.a if int(math.floor(distance)) % 2 == 0 else self.b
+
+
+class CheckersPattern(Pattern):
+    def __init__(self, a: Color, b: Color) -> None:
+        super().__init__()
+        self.a = a
+        self.b = b
+
+    def pattern_at(self, point) -> Color:
+        total = int(math.floor(point.x)) + int(math.floor(point.y)) + int(math.floor(point.z))
+        return self.a if total % 2 == 0 else self.b
+
+
+class TestPattern(Pattern):
+    def pattern_at(self, point) -> Color:
+        return Color(point.x, point.y, point.z)
 
 
 def stripe_pattern(a: Color, b: Color) -> StripePattern:
     return StripePattern(a, b)
+
+
+def gradient_pattern(a: Color, b: Color) -> GradientPattern:
+    return GradientPattern(a, b)
+
+
+def ring_pattern(a: Color, b: Color) -> RingPattern:
+    return RingPattern(a, b)
+
+
+def checkers_pattern(a: Color, b: Color) -> CheckersPattern:
+    return CheckersPattern(a, b)
+
+
+def test_pattern() -> TestPattern:
+    return TestPattern()


### PR DESCRIPTION
## Summary

- Refactor `StripePattern` into a proper `Pattern` ABC with `transform` attribute and `set_transform()`
- Add `GradientPattern` (linear interpolation in x), `RingPattern` (concentric rings in xz), `CheckersPattern` (3D checkerboard), `TestPattern` (color = xyz coords)
- `pattern_at_shape` correctly chains object transform → pattern transform before sampling
- Add `patterns.feature` with 17 BDD scenarios covering all pattern types, transforms, and combinations

## Test plan

- [x] All 149 BDD scenarios pass (`mise exec -- uv run behave`)
- [x] `ruff check` and `ruff format --check` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)