### PR TITLE
Add Python Ch 6b: World, Camera, and scene rendering

### DIFF
--- a/python/examples/chapter7.py
+++ b/python/examples/chapter7.py
@@ -1,0 +1,86 @@
+"""Chapter 7: Making a Scene — world, camera, and shadows."""
+
+from __future__ import annotations
+
+import math
+import os
+
+from rayz.camera import Camera
+from rayz.color import Color
+from rayz.point_light import PointLight
+from rayz.sphere import Sphere
+from rayz.transformations import (
+    rotation_x,
+    rotation_y,
+    scaling,
+    translation,
+    view_transform,
+)
+from rayz.tuple import Point, Vector
+from rayz.world import World
+
+
+def run() -> None:
+    print("\n=== Chapter 7: Making a Scene ===\n")
+
+    world = World()
+    world.light = PointLight(Point(-10, 10, -10), Color(1, 1, 1))
+
+    floor = Sphere()
+    floor.set_transform(scaling(10, 0.01, 10))
+    floor.material.color = Color(1, 0.9, 0.9)
+    floor.material.specular = 0
+    world.objects.append(floor)
+
+    left_wall = Sphere()
+    left_wall.set_transform(
+        translation(0, 0, 5) * rotation_y(-math.pi / 4) * rotation_x(math.pi / 2) * scaling(10, 0.01, 10)
+    )
+    left_wall.material = floor.material
+    world.objects.append(left_wall)
+
+    right_wall = Sphere()
+    right_wall.set_transform(
+        translation(0, 0, 5) * rotation_y(math.pi / 4) * rotation_x(math.pi / 2) * scaling(10, 0.01, 10)
+    )
+    right_wall.material = floor.material
+    world.objects.append(right_wall)
+
+    middle = Sphere()
+    middle.set_transform(translation(-0.5, 1, 0.5))
+    middle.material.color = Color(0.1, 1, 0.5)
+    middle.material.diffuse = 0.7
+    middle.material.specular = 0.3
+    world.objects.append(middle)
+
+    right = Sphere()
+    right.set_transform(translation(1.5, 0.5, -0.5) * scaling(0.5, 0.5, 0.5))
+    right.material.color = Color(0.5, 1, 0.1)
+    right.material.diffuse = 0.7
+    right.material.specular = 0.3
+    world.objects.append(right)
+
+    left = Sphere()
+    left.set_transform(translation(-1.5, 0.33, -0.75) * scaling(0.33, 0.33, 0.33))
+    left.material.color = Color(1, 0.8, 0.1)
+    left.material.diffuse = 0.7
+    left.material.specular = 0.3
+    world.objects.append(left)
+
+    camera = Camera(200, 100, math.pi / 3)
+    camera.transform = view_transform(Point(0, 1.5, -5), Point(0, 1, 0), Vector(0, 1, 0))
+
+    print("Rendering 200x100 scene with shadows...")
+    canvas = camera.render(world)
+
+    out_path = os.path.join(os.path.dirname(__file__), "chapter7.ppm")
+    print(f"Writing {out_path}...", end="", flush=True)
+    with open(out_path, "w") as f:
+        f.write(canvas.to_ppm())
+    print(" done.")
+    print("Scene with floor, walls, and three spheres rendered.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/examples/run.py
+++ b/python/examples/run.py
@@ -15,6 +15,7 @@ from examples.chapter3 import run as ch3
 from examples.chapter4 import run as ch4
 from examples.chapter5 import run as ch5
 from examples.chapter6 import run as ch6
+from examples.chapter7 import run as ch7
 
 CHAPTERS: dict[int, tuple[str, object]] = {
     1: ("Projectile physics", ch1),
@@ -23,6 +24,7 @@ CHAPTERS: dict[int, tuple[str, object]] = {
     4: ("Transformations", ch4),
     5: ("Ray-sphere intersections", ch5),
     6: ("Light and Shading", ch6),
+    7: ("Making a Scene", ch7),
 }
 
 

--- a/python/features/camera.feature
+++ b/python/features/camera.feature
@@ -1,0 +1,48 @@
+Feature: Camera
+
+Scenario: Constructing a camera
+  Given hsize ← 160
+    And vsize ← 120
+    And field_of_view ← π/2
+  When c ← camera(hsize, vsize, field_of_view)
+  Then c.hsize = 160
+    And c.vsize = 120
+    And c.field_of_view = π/2
+    And c.transform = identity_matrix
+
+Scenario: The pixel size for a horizontal canvas
+  Given c ← camera(200, 125, π/2)
+  Then c.pixel_size = 0.01
+
+Scenario: The pixel size for a vertical canvas
+  Given c ← camera(125, 200, π/2)
+  Then c.pixel_size = 0.01
+
+Scenario: Constructing a ray through the center of the canvas
+  Given c ← camera(201, 101, π/2)
+  When r ← ray_for_pixel(c, 100, 50)
+  Then r.origin = point(0, 0, 0)
+    And r.direction = vector(0, 0, -1)
+
+Scenario: Constructing a ray through a corner of the canvas
+  Given c ← camera(201, 101, π/2)
+  When r ← ray_for_pixel(c, 0, 0)
+  Then r.origin = point(0, 0, 0)
+    And r.direction = vector(0.66519, 0.33259, -0.66851)
+
+Scenario: Constructing a ray when the camera is transformed
+  Given c ← camera(201, 101, π/2)
+  When c.transform ← rotation_y(π/4) * translation(0, -2, 5)
+    And r ← ray_for_pixel(c, 100, 50)
+  Then r.origin = point(0, 2, -5)
+    And r.direction = vector(√2/2, 0, -√2/2)
+
+Scenario: Rendering a world with a camera
+  Given w ← default_world()
+    And c ← camera(11, 11, π/2)
+    And from ← point(0, 0, -5)
+    And to ← point(0, 0, 0)
+    And up ← vector(0, 1, 0)
+    And c.transform ← view_transform(from, to, up)
+  When image ← render(c, w)
+  Then pixel_at(image, 5, 5) = color(0.38066, 0.47583, 0.2855)

--- a/python/features/steps/camera.py
+++ b/python/features/steps/camera.py
@@ -1,0 +1,123 @@
+import pytest
+from behave import given, then, use_step_matcher, when
+
+from rayz.camera import Camera
+from rayz.color import Color
+from rayz.math_parser import parse_math
+from rayz.matrix import Matrix
+from rayz.transformations import rotation_y, translation, view_transform
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+
+IDENTITY_MATRIX = Matrix.identity(4)
+
+
+def _val(context, s):
+    """Return numeric value: look up as context attribute if it's a plain name."""
+    if hasattr(context, s):
+        return getattr(context, s)
+    return parse_math(s)
+
+
+def _make_camera(context, var, h, v, fov):
+    setattr(context, var, Camera(int(_val(context, h)), int(_val(context, v)), _val(context, fov)))
+
+
+# ---------------------------------------------------------------------------
+# Given
+# ---------------------------------------------------------------------------
+
+
+@given(rf"hsize ← {_A}")
+def step_given_hsize(context, val):
+    context.hsize = int(parse_math(val))
+
+
+@given(rf"vsize ← {_A}")
+def step_given_vsize(context, val):
+    context.vsize = int(parse_math(val))
+
+
+@given(rf"field_of_view ← {_A}")
+def step_given_fov(context, val):
+    context.field_of_view = parse_math(val)
+
+
+@given(rf"{_V} ← camera\({_A},\s*{_A},\s*{_A}\)")
+def step_given_camera(context, var, h, v, fov):
+    _make_camera(context, var, h, v, fov)
+
+
+@given(rf"{_V}\.transform ← view_transform\({_V},\s*{_V},\s*{_V}\)")
+def step_given_camera_view_transform(context, cam_var, from_var, to_var, up_var):
+    getattr(context, cam_var).transform = view_transform(
+        getattr(context, from_var),
+        getattr(context, to_var),
+        getattr(context, up_var),
+    )
+
+
+# ---------------------------------------------------------------------------
+# When
+# ---------------------------------------------------------------------------
+
+
+@when(rf"{_V} ← camera\({_A},\s*{_A},\s*{_A}\)")
+def step_when_camera(context, var, h, v, fov):
+    _make_camera(context, var, h, v, fov)
+
+
+@when(rf"{_V}\.transform ← rotation_y\({_A}\) \* translation\({_A},\s*{_A},\s*{_A}\)")
+def step_when_camera_transform(context, var, ry_val, tx, ty, tz):
+    t = rotation_y(parse_math(ry_val)) * translation(parse_math(tx), parse_math(ty), parse_math(tz))
+    getattr(context, var).transform = t
+
+
+@when(rf"r ← ray_for_pixel\({_V},\s*{_A},\s*{_A}\)")
+def step_when_ray_for_pixel(context, cam_var, px, py):
+    context.r = getattr(context, cam_var).ray_for_pixel(int(parse_math(px)), int(parse_math(py)))
+
+
+@when(rf"image ← render\({_V},\s*{_V}\)")
+def step_when_render(context, cam_var, world_var):
+    context.image = getattr(context, cam_var).render(getattr(context, world_var))
+
+
+# ---------------------------------------------------------------------------
+# Then
+# ---------------------------------------------------------------------------
+
+
+@then(rf"{_V}\.hsize = {_A}")
+def step_then_hsize(context, var, val):
+    assert getattr(context, var).hsize == int(parse_math(val))
+
+
+@then(rf"{_V}\.vsize = {_A}")
+def step_then_vsize(context, var, val):
+    assert getattr(context, var).vsize == int(parse_math(val))
+
+
+@then(rf"{_V}\.field_of_view = {_A}")
+def step_then_fov(context, var, val):
+    assert getattr(context, var).field_of_view == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"{_V}\.transform = identity_matrix")
+def step_then_camera_transform_identity(context, var):
+    assert getattr(context, var).transform == IDENTITY_MATRIX
+
+
+@then(rf"{_V}\.pixel_size = {_A}")
+def step_then_pixel_size(context, var, val):
+    assert getattr(context, var).pixel_size == pytest.approx(parse_math(val), abs=1e-4)
+
+
+@then(rf"pixel_at\(image,\s*{_A},\s*{_A}\) = color\({_A},\s*{_A},\s*{_A}\)")
+def step_then_pixel_at(context, px, py, cr, cg, cb):
+    pixel = context.image.pixel_at(col=int(parse_math(px)), row=int(parse_math(py)))
+    expected = Color(parse_math(cr), parse_math(cg), parse_math(cb))
+    assert pixel == expected, f"{pixel!r} != {expected!r}"

--- a/python/features/steps/world.py
+++ b/python/features/steps/world.py
@@ -1,0 +1,180 @@
+from behave import given, then, use_step_matcher, when
+
+from rayz.color import Color
+from rayz.intersection import Intersection, prepare_computations
+from rayz.math_parser import parse_math
+from rayz.point_light import PointLight
+from rayz.sphere import Sphere
+from rayz.transformations import scaling, translation
+from rayz.tuple import Point
+from rayz.world import World, default_world
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+
+_TRANSFORM_MAP = {"scaling": scaling, "translation": translation}
+
+
+def _apply_table(obj, table):
+    import re
+
+    # behave treats the first table row as column headers; include it as data
+    all_rows = [(table.headings[0], table.headings[1])] + [(row[0], row[1]) for row in table]
+    for prop, raw in all_rows:
+        prop, raw = prop.strip(), raw.strip()
+        if prop == "transform":
+            m = re.fullmatch(r"(scaling|translation)\((.+)\)", raw)
+            func = _TRANSFORM_MAP[m.group(1)]
+            args = [parse_math(a.strip()) for a in m.group(2).split(",")]
+            obj.set_transform(func(*args))
+        elif prop == "material.color":
+            m = re.fullmatch(r"\((.+),\s*(.+),\s*(.+)\)", raw)
+            obj.material.color = Color(parse_math(m.group(1)), parse_math(m.group(2)), parse_math(m.group(3)))
+        elif prop == "material.diffuse":
+            obj.material.diffuse = parse_math(raw)
+        elif prop == "material.specular":
+            obj.material.specular = parse_math(raw)
+        elif prop == "material.ambient":
+            obj.material.ambient = parse_math(raw)
+        elif prop == "material.reflective":
+            obj.material.reflective = parse_math(raw)
+        elif prop == "material.transparency":
+            obj.material.transparency = parse_math(raw)
+        elif prop == "material.refractive_index":
+            obj.material.refractive_index = parse_math(raw)
+
+
+# ---------------------------------------------------------------------------
+# Given
+# ---------------------------------------------------------------------------
+
+
+@given(rf"{_V} ← world\(\)")
+def step_given_world(context, var):
+    setattr(context, var, World())
+
+
+@given(rf"{_V} ← sphere\(\) with:")
+def step_given_sphere_with_table(context, var):
+    s = Sphere()
+    _apply_table(s, context.table)
+    setattr(context, var, s)
+
+
+@given(rf"{_V} is added to {_V}")
+def step_given_shape_added_to_world(context, shape_var, world_var):
+    getattr(context, world_var).objects.append(getattr(context, shape_var))
+
+
+@given(rf"{_V}\.light ← point_light\(point\({_A},\s*{_A},\s*{_A}\),\s*color\({_A},\s*{_A},\s*{_A}\)\)")
+def step_given_world_light(context, world_var, px, py, pz, ir, ig, ib):
+    getattr(context, world_var).light = PointLight(
+        Point(parse_math(px), parse_math(py), parse_math(pz)),
+        Color(parse_math(ir), parse_math(ig), parse_math(ib)),
+    )
+
+
+@given(rf"{_V} ← the first object in {_V}")
+def step_given_first_object(context, var, world_var):
+    setattr(context, var, getattr(context, world_var).objects[0])
+
+
+@given(rf"{_V} ← the second object in {_V}")
+def step_given_second_object(context, var, world_var):
+    setattr(context, var, getattr(context, world_var).objects[1])
+
+
+@given(rf"{_V}\.material\.ambient ← {_A}")
+def step_given_shape_ambient(context, var, val):
+    getattr(context, var).material.ambient = parse_math(val)
+
+
+@given(rf"{_V} ← intersection\({_A},\s*{_V}\)")
+def step_given_intersection(context, var, t_val, obj_var):
+    setattr(context, var, Intersection(parse_math(t_val), getattr(context, obj_var)))
+
+
+# ---------------------------------------------------------------------------
+# When
+# ---------------------------------------------------------------------------
+
+
+@given(rf"{_V} ← default_world\(\)")
+def step_given_default_world(context, var):
+    setattr(context, var, default_world())
+
+
+@when(rf"{_V} ← default_world\(\)")
+def step_when_default_world(context, var):
+    setattr(context, var, default_world())
+
+
+@when(rf"xs ← intersect_world\({_V},\s*{_V}\)")
+def step_when_intersect_world(context, world_var, ray_var):
+    context.xs = getattr(context, world_var).intersect_world(getattr(context, ray_var))
+
+
+@when(rf"comps ← prepare_computations\({_V},\s*{_V}\)")
+def step_when_prepare_computations(context, i_var, ray_var):
+    context.comps = prepare_computations(getattr(context, i_var), getattr(context, ray_var))
+
+
+@when(rf"c ← shade_hit\({_V},\s*comps\)")
+def step_when_shade_hit(context, world_var):
+    context.c = getattr(context, world_var).shade_hit(context.comps)
+
+
+@when(rf"c ← color_at\({_V},\s*{_V}\)")
+def step_when_color_at(context, world_var, ray_var):
+    context.c = getattr(context, world_var).color_at(getattr(context, ray_var))
+
+
+@when(rf"color ← reflected_color\({_V},\s*comps\)")
+def step_when_reflected_color(context, world_var):
+    context.color = getattr(context, world_var).reflected_color(context.comps)
+
+
+# ---------------------------------------------------------------------------
+# Then
+# ---------------------------------------------------------------------------
+
+
+@then(r"w contains no objects")
+def step_then_no_objects(context):
+    assert context.w.objects == []
+
+
+@then(r"w has no light source")
+def step_then_no_light(context):
+    assert context.w.light is None
+
+
+@then(rf"{_V}\.light = {_V}")
+def step_then_world_light(context, world_var, light_var):
+    assert getattr(context, world_var).light == getattr(context, light_var)
+
+
+@then(rf"{_V} contains {_V}")
+def step_then_world_contains(context, world_var, shape_var):
+    world = getattr(context, world_var)
+    shape = getattr(context, shape_var)
+    assert any(obj.transform == shape.transform and obj.material == shape.material for obj in world.objects)
+
+
+@then(rf"is_shadowed\({_V},\s*{_V}\) is (true|false)")
+def step_then_is_shadowed(context, world_var, point_var, expected):
+    result = getattr(context, world_var).is_shadowed(getattr(context, point_var))
+    assert result == (expected == "true")
+
+
+@then(rf"c = {_V}\.material\.color")
+def step_then_c_eq_material_color(context, shape_var):
+    assert context.c == getattr(context, shape_var).material.color
+
+
+@then(rf"color = color\({_A},\s*{_A},\s*{_A}\)")
+def step_then_color_eq(context, r, g, b):
+    expected = Color(parse_math(r), parse_math(g), parse_math(b))
+    assert context.color == expected, f"{context.color!r} != {expected!r}"

--- a/python/features/world.feature
+++ b/python/features/world.feature
@@ -1,0 +1,114 @@
+Feature: World
+
+Scenario: Creating a world
+  Given w ← world()
+  Then w contains no objects
+    And w has no light source
+
+Scenario: The default world
+  Given light ← point_light(point(-10, 10, -10), color(1, 1, 1))
+    And s1 ← sphere() with:
+      | material.color     | (0.8, 1.0, 0.6)        |
+      | material.diffuse   | 0.7                    |
+      | material.specular  | 0.2                    |
+    And s2 ← sphere() with:
+      | transform | scaling(0.5, 0.5, 0.5) |
+  When w ← default_world()
+  Then w.light = light
+    And w contains s1
+    And w contains s2
+
+Scenario: Intersect a world with a ray
+  Given w ← default_world()
+    And r ← ray(point(0, 0, -5), vector(0, 0, 1))
+  When xs ← intersect_world(w, r)
+  Then xs.count = 4
+    And xs[0].t = 4
+    And xs[1].t = 4.5
+    And xs[2].t = 5.5
+    And xs[3].t = 6
+
+Scenario: Shading an intersection
+  Given w ← default_world()
+    And r ← ray(point(0, 0, -5), vector(0, 0, 1))
+    And shape ← the first object in w
+    And i ← intersection(4, shape)
+  When comps ← prepare_computations(i, r)
+    And c ← shade_hit(w, comps)
+  Then c = color(0.38066, 0.47583, 0.2855)
+
+Scenario: Shading an intersection from the inside
+  Given w ← default_world()
+    And w.light ← point_light(point(0, 0.25, 0), color(1, 1, 1))
+    And r ← ray(point(0, 0, 0), vector(0, 0, 1))
+    And shape ← the second object in w
+    And i ← intersection(0.5, shape)
+  When comps ← prepare_computations(i, r)
+    And c ← shade_hit(w, comps)
+  Then c = color(0.90498, 0.90498, 0.90498)
+
+Scenario: The color when a ray misses
+  Given w ← default_world()
+    And r ← ray(point(0, 0, -5), vector(0, 1, 0))
+  When c ← color_at(w, r)
+  Then c = color(0, 0, 0)
+
+Scenario: The color when a ray hits
+  Given w ← default_world()
+    And r ← ray(point(0, 0, -5), vector(0, 0, 1))
+  When c ← color_at(w, r)
+  Then c = color(0.38066, 0.47583, 0.2855)
+
+Scenario: The color with an intersection behind the ray
+  Given w ← default_world()
+    And outer ← the first object in w
+    And outer.material.ambient ← 1
+    And inner ← the second object in w
+    And inner.material.ambient ← 1
+    And r ← ray(point(0, 0, 0.75), vector(0, 0, -1))
+  When c ← color_at(w, r)
+  Then c = inner.material.color
+
+Scenario: There is no shadow when nothing is collinear with point and light
+  Given w ← default_world()
+    And p ← point(0, 10, 0)
+   Then is_shadowed(w, p) is false
+
+Scenario: The shadow when an object is between the point and the light
+  Given w ← default_world()
+    And p ← point(10, -10, 10)
+   Then is_shadowed(w, p) is true
+
+Scenario: There is no shadow when an object is behind the light
+  Given w ← default_world()
+    And p ← point(-20, 20, -20)
+   Then is_shadowed(w, p) is false
+
+Scenario: There is no shadow when an object is behind the point
+  Given w ← default_world()
+    And p ← point(-2, 2, -2)
+   Then is_shadowed(w, p) is false
+
+Scenario: shade_hit() is given an intersection in shadow
+  Given w ← world()
+    And w.light ← point_light(point(0, 0, -10), color(1, 1, 1))
+    And s1 ← sphere()
+    And s1 is added to w
+    And s2 ← sphere() with:
+      | transform | translation(0, 0, 10) |
+    And s2 is added to w
+    And r ← ray(point(0, 0, 5), vector(0, 0, 1))
+    And i ← intersection(4, s2)
+  When comps ← prepare_computations(i, r)
+    And c ← shade_hit(w, comps)
+  Then c = color(0.1, 0.1, 0.1)
+
+Scenario: The reflected color for a nonreflective material
+  Given w ← default_world()
+    And r ← ray(point(0, 0, 0), vector(0, 0, 1))
+    And shape ← the second object in w
+    And shape.material.ambient ← 1
+    And i ← intersection(1, shape)
+  When comps ← prepare_computations(i, r)
+    And color ← reflected_color(w, comps)
+  Then color = color(0, 0, 0)

--- a/python/rayz/camera.py
+++ b/python/rayz/camera.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import math
+
+from rayz.canvas import Canvas
+from rayz.matrix import Matrix
+from rayz.tuple import Point
+
+
+class Camera:
+    def __init__(self, hsize: int, vsize: int, field_of_view: float) -> None:
+        self.hsize = hsize
+        self.vsize = vsize
+        self.field_of_view = field_of_view
+        self.transform = Matrix.identity(4)
+        self._calc_pixel_size()
+
+    def _calc_pixel_size(self) -> None:
+        half_view = math.tan(self.field_of_view / 2.0)
+        aspect = self.hsize / self.vsize
+        if aspect >= 1:
+            self._half_width = half_view
+            self._half_height = half_view / aspect
+        else:
+            self._half_width = half_view * aspect
+            self._half_height = half_view
+        self.pixel_size = (self._half_width * 2) / self.hsize
+
+    def ray_for_pixel(self, px: int, py: int):
+        from rayz.ray import Ray
+
+        xoffset = (px + 0.5) * self.pixel_size
+        yoffset = (py + 0.5) * self.pixel_size
+        world_x = self._half_width - xoffset
+        world_y = self._half_height - yoffset
+
+        inv = self.transform.inverse()
+        pixel_m = inv * Point(world_x, world_y, -1)
+        origin_m = inv * Point(0, 0, 0)
+        direction = (pixel_m - origin_m).normalize()
+        return Ray(origin_m, direction)
+
+    def render(self, world) -> Canvas:
+        image = Canvas(self.hsize, self.vsize)
+        for y in range(self.vsize):
+            for x in range(self.hsize):
+                ray = self.ray_for_pixel(x, y)
+                color = world.color_at(ray)
+                image.write_pixel(col=x, row=y, color=color)
+        return image

--- a/python/rayz/camera.py
+++ b/python/rayz/camera.py
@@ -46,5 +46,5 @@ class Camera:
             for x in range(self.hsize):
                 ray = self.ray_for_pixel(x, y)
                 color = world.color_at(ray)
-                image.write_pixel(col=x, row=y, color=color)
+                image.write_pixel(col=x, row=self.vsize - 1 - y, color=color)
         return image

--- a/python/rayz/computations.py
+++ b/python/rayz/computations.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+
+class Computations:
+    def __init__(
+        self, t, obj, point, eyev, normalv, inside, over_point, reflectv, n1=1.0, n2=1.0, under_point=None
+    ):
+        self.t = t
+        self.object = obj
+        self.point = point
+        self.eyev = eyev
+        self.normalv = normalv
+        self.inside = inside
+        self.over_point = over_point
+        self.reflectv = reflectv
+        self.n1 = n1
+        self.n2 = n2
+        self.under_point = under_point

--- a/python/rayz/intersection.py
+++ b/python/rayz/intersection.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from rayz.constants import EPSILON
+
 
 class Intersection:
     def __init__(self, t: float, obj) -> None:
@@ -28,3 +30,24 @@ def hit(xs: list[Intersection]) -> Intersection | None:
 
 def intersect(shape, ray) -> list[Intersection]:
     return shape.intersect(ray)
+
+
+def prepare_computations(intersection: Intersection, ray, xs=None):
+    from rayz.computations import Computations
+
+    t = intersection.t
+    obj = intersection.object
+    point = ray.position(t)
+    eyev = -ray.direction
+    normalv = obj.normal_at(point)
+
+    inside = False
+    if normalv.dot(eyev) < 0:
+        inside = True
+        normalv = -normalv
+
+    over_point = point + normalv * EPSILON
+    under_point = point - normalv * EPSILON
+    reflectv = ray.direction.reflect(normalv)
+
+    return Computations(t, obj, point, eyev, normalv, inside, over_point, reflectv, under_point=under_point)

--- a/python/rayz/world.py
+++ b/python/rayz/world.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from rayz.color import Color
+from rayz.intersection import hit, intersect, prepare_computations
+from rayz.lighting import lighting
+from rayz.point_light import PointLight
+from rayz.sphere import Sphere
+from rayz.transformations import scaling
+from rayz.tuple import Point
+
+
+class World:
+    def __init__(self) -> None:
+        self.objects: list = []
+        self.light: PointLight | None = None
+
+    @classmethod
+    def default_world(cls) -> World:
+        w = cls()
+        w.light = PointLight(Point(-10, 10, -10), Color(1, 1, 1))
+
+        s1 = Sphere()
+        s1.material.color = Color(0.8, 1.0, 0.6)
+        s1.material.diffuse = 0.7
+        s1.material.specular = 0.2
+
+        s2 = Sphere()
+        s2.set_transform(scaling(0.5, 0.5, 0.5))
+
+        w.objects = [s1, s2]
+        return w
+
+    def intersect_world(self, ray) -> list:
+        xs = []
+        for obj in self.objects:
+            xs.extend(intersect(obj, ray))
+        return sorted(xs, key=lambda i: i.t)
+
+    def is_shadowed(self, point) -> bool:
+        if self.light is None:
+            return False
+        v = self.light.position - point
+        distance = v.magnitude()
+        direction = v.normalize()
+        from rayz.ray import Ray
+
+        shadow_ray = Ray(point, direction)
+        xs = self.intersect_world(shadow_ray)
+        h = hit(xs)
+        return h is not None and h.t < distance
+
+    def reflected_color(self, comps, remaining: int = 3) -> Color:
+        if remaining <= 0 or comps.object.material.reflective == 0:
+            return Color(0, 0, 0)
+        from rayz.ray import Ray
+
+        reflect_ray = Ray(comps.over_point, comps.reflectv)
+        color = self.color_at(reflect_ray, remaining - 1)
+        return color * comps.object.material.reflective
+
+    def shade_hit(self, comps, remaining: int = 3) -> Color:
+        shadowed = self.is_shadowed(comps.over_point)
+        surface = lighting(
+            comps.object.material,
+            self.light,
+            comps.point,
+            comps.eyev,
+            comps.normalv,
+            shadowed,
+            comps.object,
+        )
+        reflected = self.reflected_color(comps, remaining)
+        return surface + reflected
+
+    def color_at(self, ray, remaining: int = 3) -> Color:
+        xs = self.intersect_world(ray)
+        h = hit(xs)
+        if h is None:
+            return Color(0, 0, 0)
+        comps = prepare_computations(h, ray, xs)
+        return self.shade_hit(comps, remaining)
+
+
+def default_world() -> World:
+    return World.default_world()


### PR DESCRIPTION
## Summary

- Add `Computations` dataclass holding pre-computed intersection data (point, eyev, normalv, over_point, reflectv)
- Add `prepare_computations(intersection, ray)` to intersection module
- Add `World` class: `intersect_world`, `shade_hit`, `color_at`, `is_shadowed`, `reflected_color` (returns black for non-reflective materials)
- Add `Camera` class: `pixel_size` calculation, `ray_for_pixel`, sequential `render`
- Add `world.feature` (14 scenarios) covering world creation, intersection, shading, shadows, and non-reflective color
- Add `camera.feature` (7 scenarios) covering construction, pixel size, ray casting through canvas, and full render
- Add `chapter7.py` example: 200×100 scene with floor, walls, and three Phong-shaded spheres with shadows

## Test plan

- [x] All 170 BDD scenarios pass (`mise exec -- uv run behave`)
- [x] `ruff check` and `ruff format --check` pass clean
- [x] Chapter 7 example runs and produces `chapter7.ppm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)