### PR TITLE
Add Python Ch 6c: Planes, reflection, and refraction

### DIFF
--- a/python/examples/chapter8.py
+++ b/python/examples/chapter8.py
@@ -1,0 +1,77 @@
+"""Chapter 8: Patterns and Planes — surfaces with patterns on infinite planes."""
+
+from __future__ import annotations
+
+import math
+import os
+
+from rayz.camera import Camera
+from rayz.color import Color
+from rayz.pattern import checkers_pattern, gradient_pattern, ring_pattern, stripe_pattern
+from rayz.plane import Plane
+from rayz.point_light import PointLight
+from rayz.sphere import Sphere
+from rayz.transformations import rotation_x, rotation_z, scaling, translation, view_transform
+from rayz.tuple import Point, Vector
+from rayz.world import World
+
+
+def run() -> None:
+    print("\n=== Chapter 8: Patterns and Planes ===\n")
+
+    world = World()
+    world.light = PointLight(Point(-10, 10, -10), Color(1, 1, 1))
+
+    floor = Plane()
+    floor.material.pattern = checkers_pattern(Color(1, 1, 1), Color(0.2, 0.2, 0.2))
+    floor.material.specular = 0
+    world.objects.append(floor)
+
+    back_wall = Plane()
+    back_wall.set_transform(rotation_x(math.pi / 2) * translation(0, 0, 5))
+    back_wall.material.pattern = gradient_pattern(Color(0.5, 0.7, 1), Color(0.1, 0.1, 0.3))
+    back_wall.material.pattern.set_transform(rotation_z(math.pi / 2) * scaling(2, 2, 2))
+    back_wall.material.specular = 0
+    world.objects.append(back_wall)
+
+    middle = Sphere()
+    middle.set_transform(translation(-0.5, 1, 0.5))
+    middle.material.pattern = ring_pattern(Color(0.1, 1, 0.5), Color(0.9, 0.1, 0.9))
+    middle.material.pattern.set_transform(scaling(0.2, 0.2, 0.2))
+    middle.material.diffuse = 0.7
+    middle.material.specular = 0.3
+    world.objects.append(middle)
+
+    right = Sphere()
+    right.set_transform(translation(1.5, 0.5, -0.5) * scaling(0.5, 0.5, 0.5))
+    right.material.pattern = stripe_pattern(Color(1, 0.2, 0.2), Color(1, 1, 0.2))
+    right.material.pattern.set_transform(scaling(0.2, 0.2, 0.2) * rotation_z(math.pi / 4))
+    right.material.diffuse = 0.7
+    right.material.specular = 0.3
+    world.objects.append(right)
+
+    left = Sphere()
+    left.set_transform(translation(-1.5, 0.33, -0.75) * scaling(0.33, 0.33, 0.33))
+    left.material.pattern = gradient_pattern(Color(1, 0.8, 0.1), Color(0.1, 0.2, 1))
+    left.material.pattern.set_transform(translation(-1, 0, 0) * scaling(2, 2, 2))
+    left.material.diffuse = 0.7
+    left.material.specular = 0.3
+    world.objects.append(left)
+
+    camera = Camera(200, 100, math.pi / 3)
+    camera.transform = view_transform(Point(0, 1.5, -5), Point(0, 1, 0), Vector(0, 1, 0))
+
+    print("Rendering 200x100 scene with patterns on planes...")
+    canvas = camera.render(world)
+
+    out_path = os.path.join(os.path.dirname(__file__), "chapter8.ppm")
+    print(f"Writing {out_path}...", end="", flush=True)
+    with open(out_path, "w") as f:
+        f.write(canvas.to_ppm())
+    print(" done.")
+    print("Patterns on planes rendered.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/examples/run.py
+++ b/python/examples/run.py
@@ -16,6 +16,7 @@ from examples.chapter4 import run as ch4
 from examples.chapter5 import run as ch5
 from examples.chapter6 import run as ch6
 from examples.chapter7 import run as ch7
+from examples.chapter8 import run as ch8
 
 CHAPTERS: dict[int, tuple[str, object]] = {
     1: ("Projectile physics", ch1),
@@ -25,6 +26,7 @@ CHAPTERS: dict[int, tuple[str, object]] = {
     5: ("Ray-sphere intersections", ch5),
     6: ("Light and Shading", ch6),
     7: ("Making a Scene", ch7),
+    8: ("Patterns and Planes", ch8),
 }
 
 

--- a/python/features/planes.feature
+++ b/python/features/planes.feature
@@ -1,0 +1,38 @@
+Feature: Planes
+
+Scenario: The normal of a plane is constant everywhere
+  Given p ← plane()
+  When n1 ← local_normal_at(p, point(0, 0, 0))
+    And n2 ← local_normal_at(p, point(10, 0, -10))
+    And n3 ← local_normal_at(p, point(-5, 0, 150))
+  Then n1 = vector(0, 1, 0)
+    And n2 = vector(0, 1, 0)
+    And n3 = vector(0, 1, 0)
+
+Scenario: Intersect with a ray parallel to the plane
+  Given p ← plane()
+    And r ← ray(point(0, 10, 0), vector(0, 0, 1))
+  When xs ← local_intersect(p, r)
+  Then xs is empty
+
+Scenario: Intersect with a coplanar ray
+  Given p ← plane()
+    And r ← ray(point(0, 0, 0), vector(0, 0, 1))
+  When xs ← local_intersect(p, r)
+  Then xs is empty
+
+Scenario: A ray intersecting a plane from above
+  Given p ← plane()
+    And r ← ray(point(0, 1, 0), vector(0, -1, 0))
+  When xs ← local_intersect(p, r)
+  Then xs.count = 1
+    And xs[0].t = 1
+    And xs[0].object = p
+
+Scenario: A ray intersecting a plane from below
+  Given p ← plane()
+    And r ← ray(point(0, -1, 0), vector(0, 1, 0))
+  When xs ← local_intersect(p, r)
+  Then xs.count = 1
+    And xs[0].t = 1
+    And xs[0].object = p

--- a/python/features/steps/intersections.py
+++ b/python/features/steps/intersections.py
@@ -1,7 +1,7 @@
 import pytest
 from behave import given, then, use_step_matcher, when
 
-from rayz.intersection import Intersection, hit, intersections
+from rayz.intersection import Intersection, hit
 from rayz.math_parser import parse_math
 from rayz.sphere import Sphere
 
@@ -27,10 +27,21 @@ def step_given_intersection(context, var, t, obj_var):
     setattr(context, var, Intersection(parse_math(t), getattr(context, obj_var)))
 
 
+def _parse_intersections(context, args):
+    items = []
+    for a in args.split(","):
+        a = a.strip()
+        if ":" in a:
+            t_str, obj_var = a.split(":", 1)
+            items.append(Intersection(parse_math(t_str.strip()), getattr(context, obj_var.strip())))
+        else:
+            items.append(getattr(context, a))
+    return items
+
+
 @given(rf"{_V} ← intersections\((.+)\)")
 def step_given_intersections(context, var, args):
-    items = [getattr(context, a.strip()) for a in args.split(",")]
-    setattr(context, var, intersections(*items))
+    setattr(context, var, sorted(_parse_intersections(context, args), key=lambda i: i.t))
 
 
 # ---------------------------------------------------------------------------
@@ -45,8 +56,7 @@ def step_when_intersection(context, var, t, obj_var):
 
 @when(rf"{_V} ← intersections\((.+)\)")
 def step_when_intersections(context, var, args):
-    items = [getattr(context, a.strip()) for a in args.split(",")]
-    setattr(context, var, intersections(*items))
+    setattr(context, var, sorted(_parse_intersections(context, args), key=lambda i: i.t))
 
 
 @when(rf"{_V} ← hit\({_V}\)")

--- a/python/features/steps/planes.py
+++ b/python/features/steps/planes.py
@@ -1,0 +1,58 @@
+from behave import given, then, use_step_matcher, when
+
+from rayz.math_parser import parse_math
+from rayz.plane import Plane
+from rayz.tuple import Point, Vector
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+
+
+@given(rf"{_V} ← plane\(\)")
+def step_given_plane(context, var):
+    setattr(context, var, Plane())
+
+
+@when(rf"n1 ← local_normal_at\({_V},\s*point\({_A},\s*{_A},\s*{_A}\)\)")
+def step_when_local_normal_at_1(context, var, x, y, z):
+    context.n1 = getattr(context, var).local_normal_at(Point(parse_math(x), parse_math(y), parse_math(z)))
+
+
+@when(rf"n2 ← local_normal_at\({_V},\s*point\({_A},\s*{_A},\s*{_A}\)\)")
+def step_when_local_normal_at_2(context, var, x, y, z):
+    context.n2 = getattr(context, var).local_normal_at(Point(parse_math(x), parse_math(y), parse_math(z)))
+
+
+@when(rf"n3 ← local_normal_at\({_V},\s*point\({_A},\s*{_A},\s*{_A}\)\)")
+def step_when_local_normal_at_3(context, var, x, y, z):
+    context.n3 = getattr(context, var).local_normal_at(Point(parse_math(x), parse_math(y), parse_math(z)))
+
+
+@when(rf"xs ← local_intersect\({_V},\s*{_V}\)")
+def step_when_local_intersect(context, shape_var, ray_var):
+    context.xs = getattr(context, shape_var).local_intersect(getattr(context, ray_var))
+
+
+@then(r"xs is empty")
+def step_then_xs_empty(context):
+    assert context.xs == []
+
+
+@then(rf"n1 = vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_n1_eq_vector(context, x, y, z):
+    expected = Vector(parse_math(x), parse_math(y), parse_math(z))
+    assert context.n1 == expected
+
+
+@then(rf"n2 = vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_n2_eq_vector(context, x, y, z):
+    expected = Vector(parse_math(x), parse_math(y), parse_math(z))
+    assert context.n2 == expected
+
+
+@then(rf"n3 = vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_n3_eq_vector(context, x, y, z):
+    expected = Vector(parse_math(x), parse_math(y), parse_math(z))
+    assert context.n3 == expected

--- a/python/features/steps/world.py
+++ b/python/features/steps/world.py
@@ -1,8 +1,10 @@
+import pytest
 from behave import given, then, use_step_matcher, when
 
 from rayz.color import Color
 from rayz.intersection import Intersection, prepare_computations
 from rayz.math_parser import parse_math
+from rayz.plane import Plane
 from rayz.point_light import PointLight
 from rayz.sphere import Sphere
 from rayz.transformations import scaling, translation
@@ -44,6 +46,11 @@ def _apply_table(obj, table):
             obj.material.transparency = parse_math(raw)
         elif prop == "material.refractive_index":
             obj.material.refractive_index = parse_math(raw)
+        elif prop == "material.pattern":
+            if raw == "test_pattern()":
+                from rayz.pattern import test_pattern
+
+                obj.material.pattern = test_pattern()
 
 
 # ---------------------------------------------------------------------------
@@ -176,5 +183,55 @@ def step_then_c_eq_material_color(context, shape_var):
 
 @then(rf"color = color\({_A},\s*{_A},\s*{_A}\)")
 def step_then_color_eq(context, r, g, b):
-    expected = Color(parse_math(r), parse_math(g), parse_math(b))
-    assert context.color == expected, f"{context.color!r} != {expected!r}"
+    c = context.color
+    assert c.red == pytest.approx(parse_math(r), abs=1e-4)
+    assert c.green == pytest.approx(parse_math(g), abs=1e-4)
+    assert c.blue == pytest.approx(parse_math(b), abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Planes + reflection/refraction additions
+# ---------------------------------------------------------------------------
+
+
+@given(rf"{_V} ← plane\(\) with:")
+def step_given_plane_with_table(context, var):
+    p = Plane()
+    _apply_table(p, context.table)
+    setattr(context, var, p)
+
+
+@given(rf"{_V} has:")
+def step_given_shape_has_table(context, var):
+    _apply_table(getattr(context, var), context.table)
+
+
+@when(rf"comps ← prepare_computations\(xs\[(\d+)\],\s*{_V},\s*xs\)")
+def step_when_prepare_computations_xs(context, idx, ray_var):
+    context.comps = prepare_computations(context.xs[int(idx)], getattr(context, ray_var), context.xs)
+
+
+@when(rf"c ← refracted_color\({_V},\s*comps,\s*(\d+)\)")
+def step_when_refracted_color(context, world_var, remaining):
+    context.c = getattr(context, world_var).refracted_color(context.comps, int(remaining))
+
+
+@when(rf"color ← reflected_color\({_V},\s*comps,\s*(\d+)\)")
+def step_when_reflected_color_remaining(context, world_var, remaining):
+    context.color = getattr(context, world_var).reflected_color(context.comps, int(remaining))
+
+
+@when(rf"color ← shade_hit\({_V},\s*comps\)")
+def step_when_shade_hit_color(context, world_var):
+    context.color = getattr(context, world_var).shade_hit(context.comps)
+
+
+@when(rf"color ← shade_hit\({_V},\s*comps,\s*(\d+)\)")
+def step_when_shade_hit_remaining(context, world_var, remaining):
+    context.color = getattr(context, world_var).shade_hit(context.comps, int(remaining))
+
+
+@then(rf"color_at\({_V},\s*{_V}\) should terminate successfully")
+def step_then_color_at_terminates(context, world_var, ray_var):
+    result = getattr(context, world_var).color_at(getattr(context, ray_var))
+    assert result is not None

--- a/python/features/world.feature
+++ b/python/features/world.feature
@@ -112,3 +112,139 @@ Scenario: The reflected color for a nonreflective material
   When comps ← prepare_computations(i, r)
     And color ← reflected_color(w, comps)
   Then color = color(0, 0, 0)
+
+Scenario: The reflected color for a reflective material
+  Given w ← default_world()
+    And shape ← plane() with:
+      | material.reflective | 0.5                   |
+      | transform           | translation(0, -1, 0) |
+    And shape is added to w
+    And r ← ray(point(0, 0, -3), vector(0, -√2/2, √2/2))
+    And i ← intersection(√2, shape)
+  When comps ← prepare_computations(i, r)
+    And color ← reflected_color(w, comps)
+  Then color = color(0.19032, 0.2379, 0.14274)
+
+Scenario: shade_hit() with a reflective material
+  Given w ← default_world()
+    And shape ← plane() with:
+      | material.reflective | 0.5                   |
+      | transform           | translation(0, -1, 0) |
+    And shape is added to w
+    And r ← ray(point(0, 0, -3), vector(0, -√2/2, √2/2))
+    And i ← intersection(√2, shape)
+  When comps ← prepare_computations(i, r)
+    And color ← shade_hit(w, comps)
+  Then color = color(0.87677, 0.92436, 0.82918)
+
+Scenario: color_at() with mutually reflective surfaces
+  Given w ← world()
+    And w.light ← point_light(point(0, 0, 0), color(1, 1, 1))
+    And lower ← plane() with:
+      | material.reflective | 1                     |
+      | transform           | translation(0, -1, 0) |
+    And lower is added to w
+    And upper ← plane() with:
+      | material.reflective | 1                    |
+      | transform           | translation(0, 1, 0) |
+    And upper is added to w
+    And r ← ray(point(0, 0, 0), vector(0, 1, 0))
+  Then color_at(w, r) should terminate successfully
+
+Scenario: The reflected color at the maximum recursive depth
+  Given w ← default_world()
+    And shape ← plane() with:
+      | material.reflective | 0.5                   |
+      | transform           | translation(0, -1, 0) |
+    And shape is added to w
+    And r ← ray(point(0, 0, -3), vector(0, -√2/2, √2/2))
+    And i ← intersection(√2, shape)
+  When comps ← prepare_computations(i, r)
+    And color ← reflected_color(w, comps, 0)
+  Then color = color(0, 0, 0)
+
+Scenario: The refracted color with an opaque surface
+  Given w ← default_world()
+    And shape ← the first object in w
+    And r ← ray(point(0, 0, -5), vector(0, 0, 1))
+    And xs ← intersections(4:shape, 6:shape)
+  When comps ← prepare_computations(xs[0], r, xs)
+    And c ← refracted_color(w, comps, 5)
+  Then c = color(0, 0, 0)
+
+Scenario: The refracted color at the maximum recursive depth
+  Given w ← default_world()
+    And shape ← the first object in w
+    And shape has:
+      | material.transparency     | 1.0 |
+      | material.refractive_index | 1.5 |
+    And r ← ray(point(0, 0, -5), vector(0, 0, 1))
+    And xs ← intersections(4:shape, 6:shape)
+  When comps ← prepare_computations(xs[0], r, xs)
+    And c ← refracted_color(w, comps, 0)
+  Then c = color(0, 0, 0)
+
+Scenario: The refracted color under total internal reflection
+  Given w ← default_world()
+    And shape ← the first object in w
+    And shape has:
+      | material.transparency     | 1.0 |
+      | material.refractive_index | 1.5 |
+    And r ← ray(point(0, 0, √2/2), vector(0, 1, 0))
+    And xs ← intersections(-√2/2:shape, √2/2:shape)
+  When comps ← prepare_computations(xs[1], r, xs)
+    And c ← refracted_color(w, comps, 5)
+  Then c = color(0, 0, 0)
+
+Scenario: The refracted color with a refracted ray
+  Given w ← default_world()
+    And A ← the first object in w
+    And A has:
+      | material.ambient | 1.0            |
+      | material.pattern | test_pattern() |
+    And B ← the second object in w
+    And B has:
+      | material.transparency     | 1.0 |
+      | material.refractive_index | 1.5 |
+    And r ← ray(point(0, 0, 0.1), vector(0, 1, 0))
+    And xs ← intersections(-0.9899:A, -0.4899:B, 0.4899:B, 0.9899:A)
+  When comps ← prepare_computations(xs[2], r, xs)
+    And c ← refracted_color(w, comps, 5)
+  Then c = color(0, 0.99888, 0.04725)
+
+Scenario: shade_hit() with a transparent material
+  Given w ← default_world()
+    And floor ← plane() with:
+      | transform                 | translation(0, -1, 0) |
+      | material.transparency     | 0.5                   |
+      | material.refractive_index | 1.5                   |
+    And floor is added to w
+    And ball ← sphere() with:
+      | material.color   | (1, 0, 0)                  |
+      | material.ambient | 0.5                        |
+      | transform        | translation(0, -3.5, -0.5) |
+    And ball is added to w
+    And r ← ray(point(0, 0, -3), vector(0, -√2/2, √2/2))
+    And xs ← intersections(√2:floor)
+  When comps ← prepare_computations(xs[0], r, xs)
+    And color ← shade_hit(w, comps, 5)
+  Then color = color(0.93642, 0.68642, 0.68642)
+
+Scenario: shade_hit() with a reflective, transparent material
+  Given w ← default_world()
+    And r ← ray(point(0, 0, -3), vector(0, -√2/2, √2/2))
+    And floor ← plane() with:
+      | transform                 | translation(0, -1, 0) |
+      | material.reflective       | 0.5                   |
+      | material.transparency     | 0.5                   |
+      | material.refractive_index | 1.5                   |
+    And floor is added to w
+    And ball ← sphere() with:
+      | material.color   | (1, 0, 0)                  |
+      | material.ambient | 0.5                        |
+      | transform        | translation(0, -3.5, -0.5) |
+    And ball is added to w
+    And xs ← intersections(√2:floor)
+  When comps ← prepare_computations(xs[0], r, xs)
+    And color ← shade_hit(w, comps, 5)
+  Then color = color(0.93391, 0.69643, 0.69243)

--- a/python/rayz/color.py
+++ b/python/rayz/color.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from rayz.constants import EPSILON
-
 
 class Color:
     """An RGB color with floating-point components."""
@@ -15,9 +13,9 @@ class Color:
         if not isinstance(other, Color):
             return NotImplemented
         return (
-            abs(self.red - other.red) < EPSILON
-            and abs(self.green - other.green) < EPSILON
-            and abs(self.blue - other.blue) < EPSILON
+            abs(self.red - other.red) < 1e-4
+            and abs(self.green - other.green) < 1e-4
+            and abs(self.blue - other.blue) < 1e-4
         )
 
     __hash__ = None  # type: ignore[assignment]

--- a/python/rayz/intersection.py
+++ b/python/rayz/intersection.py
@@ -50,4 +50,30 @@ def prepare_computations(intersection: Intersection, ray, xs=None):
     under_point = point - normalv * EPSILON
     reflectv = ray.direction.reflect(normalv)
 
-    return Computations(t, obj, point, eyev, normalv, inside, over_point, reflectv, under_point=under_point)
+    n1, n2 = 1.0, 1.0
+    if xs is not None:
+        containers: list = []
+        for i in xs:
+            if i == intersection:
+                n1 = containers[-1].material.refractive_index if containers else 1.0
+            if i.object in containers:
+                containers.remove(i.object)
+            else:
+                containers.append(i.object)
+            if i == intersection:
+                n2 = containers[-1].material.refractive_index if containers else 1.0
+                break
+
+    return Computations(
+        t,
+        obj,
+        point,
+        eyev,
+        normalv,
+        inside,
+        over_point,
+        reflectv,
+        n1=n1,
+        n2=n2,
+        under_point=under_point,
+    )

--- a/python/rayz/plane.py
+++ b/python/rayz/plane.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from rayz.constants import EPSILON
+from rayz.intersection import Intersection
+from rayz.shape import Shape
+from rayz.tuple import Vector
+
+
+class Plane(Shape):
+    def local_intersect(self, ray) -> list:
+        if abs(ray.direction.y) < EPSILON:
+            return []
+        t = -ray.origin.y / ray.direction.y
+        return [Intersection(t, self)]
+
+    def local_normal_at(self, point) -> Vector:
+        return Vector(0, 1, 0)

--- a/python/rayz/world.py
+++ b/python/rayz/world.py
@@ -55,8 +55,25 @@ class World:
         from rayz.ray import Ray
 
         reflect_ray = Ray(comps.over_point, comps.reflectv)
-        color = self.color_at(reflect_ray, remaining - 1)
-        return color * comps.object.material.reflective
+        return self.color_at(reflect_ray, remaining - 1) * comps.object.material.reflective
+
+    def refracted_color(self, comps, remaining: int = 3) -> Color:
+        if remaining <= 0 or comps.object.material.transparency == 0:
+            return Color(0, 0, 0)
+        import math
+
+        n_ratio = comps.n1 / comps.n2
+        cos_i = comps.eyev.dot(comps.normalv)
+        sin2_t = n_ratio * n_ratio * (1 - cos_i * cos_i)
+        if sin2_t > 1.0:
+            return Color(0, 0, 0)
+
+        cos_t = math.sqrt(1.0 - sin2_t)
+        direction = comps.normalv * (n_ratio * cos_i - cos_t) - comps.eyev * n_ratio
+        from rayz.ray import Ray
+
+        refract_ray = Ray(comps.under_point, direction)
+        return self.color_at(refract_ray, remaining - 1) * comps.object.material.transparency
 
     def shade_hit(self, comps, remaining: int = 3) -> Color:
         shadowed = self.is_shadowed(comps.over_point)
@@ -70,7 +87,12 @@ class World:
             comps.object,
         )
         reflected = self.reflected_color(comps, remaining)
-        return surface + reflected
+        refracted = self.refracted_color(comps, remaining)
+        mat = comps.object.material
+        if mat.reflective > 0 and mat.transparency > 0:
+            reflectance = schlick(comps)
+            return surface + reflected * reflectance + refracted * (1 - reflectance)
+        return surface + reflected + refracted
 
     def color_at(self, ray, remaining: int = 3) -> Color:
         xs = self.intersect_world(ray)
@@ -83,3 +105,17 @@ class World:
 
 def default_world() -> World:
     return World.default_world()
+
+
+def schlick(comps) -> float:
+    import math
+
+    cos = comps.eyev.dot(comps.normalv)
+    if comps.n1 > comps.n2:
+        n = comps.n1 / comps.n2
+        sin2_t = n * n * (1.0 - cos * cos)
+        if sin2_t > 1.0:
+            return 1.0
+        cos = math.sqrt(1.0 - sin2_t)
+    r0 = ((comps.n1 - comps.n2) / (comps.n1 + comps.n2)) ** 2
+    return r0 + (1 - r0) * (1 - cos) ** 5


### PR DESCRIPTION
## Summary

- Add `Plane` shape extending `Shape` ABC: constant upward normal, handles parallel/coplanar rays
- Add `schlick()` Fresnel approximation for realistic reflection/refraction blending
- Add `refracted_color()` to `World` using Snell's law with total-internal-reflection check
- Update `shade_hit()` to combine surface + reflected + refracted (Schlick-blended when both active)
- Update `prepare_computations()` to track n1/n2 refractive indices across intersection boundaries
- Extend `intersections` step to handle `t:var` colon syntax used in refraction scenarios
- Widen `Color.__eq__` tolerance to `1e-4` (book expected values are rounded to 5 decimal places)
- Add `planes.feature` (5 scenarios) and 10 new `world.feature` reflection/refraction scenarios
- Add `chapter8.py` example: checkers floor, gradient back wall, ring/stripe/gradient spheres on infinite planes

## Test plan

- [x] All 185 BDD scenarios pass (`mise exec -- uv run behave`)
- [x] `ruff check` and `ruff format --check` pass clean
- [x] Chapter 8 example runs and produces `chapter8.ppm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)