### PR TITLE
Add Python Ch 8: Cubes

### DIFF
--- a/python/examples/chapter11.py
+++ b/python/examples/chapter11.py
@@ -1,0 +1,104 @@
+"""Chapter 11: Cubes — room, table, and boxes."""
+
+from __future__ import annotations
+
+import math
+import os
+
+from rayz.camera import Camera
+from rayz.color import Color
+from rayz.cube import Cube
+from rayz.pattern import checkers_pattern
+from rayz.point_light import PointLight
+from rayz.transformations import rotation_y, scaling, translation, view_transform
+from rayz.tuple import Point, Vector
+from rayz.world import World
+
+
+def run() -> None:
+    print("\n=== Chapter 11: Cubes ===\n")
+
+    world = World()
+    world.light = PointLight(Point(2, 10, -5), Color(0.9, 0.9, 0.9))
+
+    room = Cube()
+    room.set_transform(scaling(15, 15, 15))
+    room.material.pattern = checkers_pattern(Color(0.15, 0.15, 0.15), Color(0.25, 0.25, 0.25))
+    room.material.ambient = 0.3
+    room.material.diffuse = 0.7
+    room.material.specular = 0.0
+    room.material.reflective = 0.1
+    world.objects.append(room)
+
+    table_top = Cube()
+    table_top.set_transform(translation(0, 3.1, 0) * scaling(3, 0.1, 2))
+    table_top.material.color = Color(0.6, 0.3, 0.1)
+    table_top.material.ambient = 0.2
+    table_top.material.diffuse = 0.7
+    table_top.material.specular = 0.3
+    table_top.material.shininess = 20
+    world.objects.append(table_top)
+
+    for tx, tz in [(-2.7, -1.7), (2.7, -1.7), (-2.7, 1.7), (2.7, 1.7)]:
+        leg = Cube()
+        leg.set_transform(translation(tx, 1.5, tz) * scaling(0.1, 1.5, 0.1))
+        leg.material.color = Color(0.5, 0.25, 0.1)
+        leg.material.ambient = 0.2
+        leg.material.diffuse = 0.7
+        world.objects.append(leg)
+
+    glass_cube = Cube()
+    glass_cube.set_transform(translation(0, 3.8, 0) * rotation_y(math.pi / 6) * scaling(0.5, 0.5, 0.5))
+    glass_cube.material.color = Color(0.1, 0.1, 0.1)
+    glass_cube.material.ambient = 0.0
+    glass_cube.material.diffuse = 0.1
+    glass_cube.material.specular = 1.0
+    glass_cube.material.shininess = 300
+    glass_cube.material.reflective = 0.9
+    glass_cube.material.transparency = 0.9
+    glass_cube.material.refractive_index = 1.5
+    world.objects.append(glass_cube)
+
+    metal_cube = Cube()
+    metal_cube.set_transform(translation(1.5, 4.0, 1.0) * rotation_y(math.pi / 4) * scaling(0.7, 0.7, 0.7))
+    metal_cube.material.color = Color(0.3, 0.3, 0.3)
+    metal_cube.material.ambient = 0.1
+    metal_cube.material.diffuse = 0.3
+    metal_cube.material.specular = 0.9
+    metal_cube.material.shininess = 200
+    metal_cube.material.reflective = 0.8
+    world.objects.append(metal_cube)
+
+    small_cube = Cube()
+    small_cube.set_transform(translation(-1.8, 3.6, -0.5) * rotation_y(math.pi / 8) * scaling(0.4, 0.4, 0.4))
+    small_cube.material.color = Color(0.8, 0.2, 0.2)
+    small_cube.material.ambient = 0.2
+    small_cube.material.diffuse = 0.8
+    small_cube.material.specular = 0.3
+    world.objects.append(small_cube)
+
+    floor_box = Cube()
+    floor_box.set_transform(translation(4, 0.6, 3) * rotation_y(math.pi / 5) * scaling(0.6, 0.6, 0.6))
+    floor_box.material.color = Color(0.2, 0.4, 0.8)
+    floor_box.material.ambient = 0.2
+    floor_box.material.diffuse = 0.8
+    floor_box.material.specular = 0.2
+    world.objects.append(floor_box)
+
+    camera = Camera(200, 150, math.pi / 3)
+    camera.transform = view_transform(Point(8, 6, -8), Point(0, 3, 0), Vector(0, 1, 0))
+
+    print("Rendering 200x150 scene with cubes (room, table, boxes)...")
+    canvas = camera.render(world)
+
+    out_path = os.path.join(os.path.dirname(__file__), "chapter11.ppm")
+    print(f"Writing {out_path}...", end="", flush=True)
+    with open(out_path, "w") as f:
+        f.write(canvas.to_ppm())
+    print(" done.")
+    print("Cubes scene rendered.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/examples/run.py
+++ b/python/examples/run.py
@@ -19,6 +19,7 @@ from examples.chapter7 import run as ch7
 from examples.chapter8 import run as ch8
 from examples.chapter9 import run as ch9
 from examples.chapter10 import run as ch10
+from examples.chapter11 import run as ch11
 
 CHAPTERS: dict[int, tuple[str, object]] = {
     1: ("Projectile physics", ch1),
@@ -31,6 +32,7 @@ CHAPTERS: dict[int, tuple[str, object]] = {
     8: ("Patterns and Planes", ch8),
     9: ("Planes", ch9),
     10: ("Reflection and Refraction", ch10),
+    11: ("Cubes", ch11),
 }
 
 

--- a/python/features/cubes.feature
+++ b/python/features/cubes.feature
@@ -1,0 +1,52 @@
+Feature: Cubes
+
+Scenario Outline: A ray intersects a cube
+  Given c ← cube()
+    And r ← ray(<origin>, <direction>)
+  When xs ← local_intersect(c, r)
+  Then xs.count = 2
+    And xs[0].t = <t1>
+    And xs[1].t = <t2>
+
+  Examples:
+    |        | origin            | direction        | t1 | t2 |
+    | +x     | point(5, 0.5, 0)  | vector(-1, 0, 0) |  4 |  6 |
+    | -x     | point(-5, 0.5, 0) | vector(1, 0, 0)  |  4 |  6 |
+    | +y     | point(0.5, 5, 0)  | vector(0, -1, 0) |  4 |  6 |
+    | -y     | point(0.5, -5, 0) | vector(0, 1, 0)  |  4 |  6 |
+    | +z     | point(0.5, 0, 5)  | vector(0, 0, -1) |  4 |  6 |
+    | -z     | point(0.5, 0, -5) | vector(0, 0, 1)  |  4 |  6 |
+    | inside | point(0, 0.5, 0)  | vector(0, 0, 1)  | -1 |  1 |
+
+Scenario Outline: A ray misses a cube
+  Given c ← cube()
+    And r ← ray(<origin>, <direction>)
+  When xs ← local_intersect(c, r)
+  Then xs.count = 0
+
+  Examples:
+    | origin           | direction                      |
+    | point(-2, 0, 0)  | vector(0.2673, 0.5345, 0.8018) |
+    | point(0, -2, 0)  | vector(0.8018, 0.2673, 0.5345) |
+    | point(0, 0, -2)  | vector(0.5345, 0.8018, 0.2673) |
+    | point(2, 0, 2)   | vector(0, 0, -1)               |
+    | point(0, 2, 2)   | vector(0, -1, 0)               |
+    | point(2, 2, 0)   | vector(-1, 0, 0)               |
+
+
+Scenario Outline: The normal on the surface of a cube
+  Given c ← cube()
+    And p ← <point>
+  When normal ← local_normal_at(c, p)
+  Then normal = <normal>
+
+  Examples:
+    | point                | normal           |
+    | point(1, 0.5, -0.8)  | vector(1, 0, 0)  |
+    | point(-1, -0.2, 0.9) | vector(-1, 0, 0) |
+    | point(-0.4, 1, -0.1) | vector(0, 1, 0)  |
+    | point(0.3, -1, -0.7) | vector(0, -1, 0) |
+    | point(-0.6, 0.3, 1)  | vector(0, 0, 1)  |
+    | point(0.4, 0.4, -1)  | vector(0, 0, -1) |
+    | point(1, 1, 1)       | vector(1, 0, 0)  |
+    | point(-1, -1, -1)    | vector(-1, 0, 0) |

--- a/python/features/steps/cubes.py
+++ b/python/features/steps/cubes.py
@@ -1,0 +1,36 @@
+from behave import given, then, use_step_matcher, when
+
+from rayz.cube import Cube
+from rayz.math_parser import parse_math
+from rayz.tuple import Point, Vector
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+
+
+@given(rf"{_V} ← cube\(\)")
+def step_given_cube(context, var):
+    setattr(context, var, Cube())
+
+
+@given(rf"p ← point\({_A},\s*{_A},\s*{_A}\)")
+def step_given_p_point(context, x, y, z):
+    context.p = Point(parse_math(x), parse_math(y), parse_math(z))
+
+
+@when(rf"xs ← local_intersect\({_V},\s*{_V}\)")
+def step_when_local_intersect(context, shape_var, ray_var):
+    context.xs = getattr(context, shape_var).local_intersect(getattr(context, ray_var))
+
+
+@when(rf"normal ← local_normal_at\({_V},\s*{_V}\)")
+def step_when_local_normal_at(context, shape_var, point_var):
+    context.normal = getattr(context, shape_var).local_normal_at(getattr(context, point_var))
+
+
+@then(rf"normal = vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_normal_eq_vector(context, x, y, z):
+    expected = Vector(parse_math(x), parse_math(y), parse_math(z))
+    assert context.normal == expected, f"{context.normal!r} != {expected!r}"

--- a/python/rayz/cube.py
+++ b/python/rayz/cube.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from rayz.constants import EPSILON
+from rayz.intersection import Intersection
+from rayz.shape import Shape
+from rayz.tuple import Vector
+
+
+class Cube(Shape):
+    def local_intersect(self, ray) -> list:
+        xtmin, xtmax = _check_axis(ray.origin.x, ray.direction.x)
+        ytmin, ytmax = _check_axis(ray.origin.y, ray.direction.y)
+        ztmin, ztmax = _check_axis(ray.origin.z, ray.direction.z)
+
+        tmin = max(xtmin, ytmin, ztmin)
+        tmax = min(xtmax, ytmax, ztmax)
+
+        if tmin > tmax:
+            return []
+        return [Intersection(tmin, self), Intersection(tmax, self)]
+
+    def local_normal_at(self, point) -> Vector:
+        ax, ay, az = abs(point.x), abs(point.y), abs(point.z)
+        maxc = max(ax, ay, az)
+        if maxc == ax:
+            return Vector(point.x, 0, 0)
+        elif maxc == ay:
+            return Vector(0, point.y, 0)
+        return Vector(0, 0, point.z)
+
+
+def _check_axis(origin: float, direction: float) -> tuple[float, float]:
+    tmin_num = -1 - origin
+    tmax_num = 1 - origin
+    if abs(direction) >= EPSILON:
+        tmin = tmin_num / direction
+        tmax = tmax_num / direction
+    else:
+        tmin = tmin_num * float("inf")
+        tmax = tmax_num * float("inf")
+    if tmin > tmax:
+        return tmax, tmin
+    return tmin, tmax


### PR DESCRIPTION
## Summary

- Add `Cube` shape extending `Shape` ABC: slab intersection method using `check_axis` per dimension, face normal via max-absolute-component
- Add `cubes.feature` with 21 scenarios (Scenario Outlines): 7 ray-hits, 6 ray-misses, 8 normals
- Add `chapter11.py` example: room made from a large cube with checkers pattern, table with 4 legs, glass/reflective/colored cubes on and around the table

## Test plan

- [x] All 206 BDD scenarios pass (`mise exec -- uv run behave`)
- [x] `ruff check` and `ruff format --check` pass clean
- [x] Chapter 11 example runs and produces `chapter11.ppm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)