### PR TITLE
Add Python Ch 9: Cylinders

### DIFF
--- a/python/examples/chapter12.py
+++ b/python/examples/chapter12.py
@@ -1,0 +1,117 @@
+"""Chapter 12: Cylinders — table with legs, glass, metal, and candle cylinders."""
+
+from __future__ import annotations
+
+import math
+import os
+
+from rayz.camera import Camera
+from rayz.color import Color
+from rayz.cylinder import Cylinder
+from rayz.pattern import checkers_pattern
+from rayz.plane import Plane
+from rayz.point_light import PointLight
+from rayz.transformations import rotation_y, rotation_z, scaling, translation, view_transform
+from rayz.tuple import Point, Vector
+from rayz.world import World
+
+
+def run() -> None:
+    print("\n=== Chapter 12: Cylinders ===\n")
+
+    world = World()
+    world.light = PointLight(Point(10, 10, -10), Color(1, 1, 1))
+
+    floor = Plane()
+    floor.material.pattern = checkers_pattern(Color(0.5, 0.5, 0.5), Color(0.75, 0.75, 0.75))
+    floor.material.reflective = 0.1
+    world.objects.append(floor)
+
+    for tx, tz in [(-2, 1.5), (2, 1.5), (-2, -1.5), (2, -1.5)]:
+        leg = Cylinder()
+        leg.minimum = 0
+        leg.maximum = 3
+        leg.closed = True
+        leg.set_transform(translation(tx, 0, tz) * scaling(0.15, 1, 0.15))
+        leg.material.color = Color(0.6, 0.4, 0.2)
+        leg.material.diffuse = 0.8
+        leg.material.specular = 0.3
+        world.objects.append(leg)
+
+    table_top = Cylinder()
+    table_top.minimum = 0
+    table_top.maximum = 0.2
+    table_top.closed = True
+    table_top.set_transform(translation(0, 3, 0) * scaling(2.5, 1, 2))
+    table_top.material.color = Color(0.7, 0.45, 0.25)
+    table_top.material.ambient = 0.1
+    table_top.material.diffuse = 0.7
+    table_top.material.specular = 0.4
+    table_top.material.shininess = 50
+    world.objects.append(table_top)
+
+    glass = Cylinder()
+    glass.minimum = 0
+    glass.maximum = 1.5
+    glass.set_transform(translation(-1, 3.2, 0) * scaling(0.4, 1, 0.4))
+    glass.material.color = Color(0.8, 0.9, 1.0)
+    glass.material.ambient = 0.0
+    glass.material.diffuse = 0.1
+    glass.material.specular = 1.0
+    glass.material.shininess = 300
+    glass.material.reflective = 0.9
+    glass.material.transparency = 0.9
+    glass.material.refractive_index = 1.5
+    world.objects.append(glass)
+
+    metal = Cylinder()
+    metal.minimum = 0
+    metal.maximum = 0.8
+    metal.closed = True
+    metal.set_transform(translation(1, 3.2, 0.5) * rotation_y(math.pi / 6) * scaling(0.3, 1, 0.3))
+    metal.material.color = Color(0.7, 0.7, 0.7)
+    metal.material.ambient = 0.1
+    metal.material.diffuse = 0.6
+    metal.material.specular = 0.9
+    metal.material.shininess = 200
+    metal.material.reflective = 0.8
+    world.objects.append(metal)
+
+    colored = Cylinder()
+    colored.minimum = 0
+    colored.maximum = 2
+    colored.closed = True
+    colored.set_transform(translation(0.5, 3.2, -0.8) * rotation_z(math.pi / 8) * scaling(0.15, 1, 0.15))
+    colored.material.color = Color(0.8, 0.2, 0.3)
+    colored.material.ambient = 0.2
+    colored.material.diffuse = 0.8
+    colored.material.specular = 0.3
+    world.objects.append(colored)
+
+    candle = Cylinder()
+    candle.minimum = 0
+    candle.maximum = 1.2
+    candle.closed = True
+    candle.set_transform(translation(-4, 0, -3) * scaling(0.2, 1, 0.2))
+    candle.material.color = Color(0.9, 0.9, 0.8)
+    candle.material.ambient = 0.3
+    candle.material.diffuse = 0.6
+    world.objects.append(candle)
+
+    camera = Camera(200, 150, math.pi / 3)
+    camera.transform = view_transform(Point(8, 6, -8), Point(0, 3, 0), Vector(0, 1, 0))
+
+    print("Rendering 200x150 scene with cylinders...")
+    canvas = camera.render(world)
+
+    out_path = os.path.join(os.path.dirname(__file__), "chapter12.ppm")
+    print(f"Writing {out_path}...", end="", flush=True)
+    with open(out_path, "w") as f:
+        f.write(canvas.to_ppm())
+    print(" done.")
+    print("Cylinders scene rendered.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/examples/run.py
+++ b/python/examples/run.py
@@ -20,6 +20,7 @@ from examples.chapter8 import run as ch8
 from examples.chapter9 import run as ch9
 from examples.chapter10 import run as ch10
 from examples.chapter11 import run as ch11
+from examples.chapter12 import run as ch12
 
 CHAPTERS: dict[int, tuple[str, object]] = {
     1: ("Projectile physics", ch1),
@@ -33,6 +34,7 @@ CHAPTERS: dict[int, tuple[str, object]] = {
     9: ("Planes", ch9),
     10: ("Reflection and Refraction", ch10),
     11: ("Cubes", ch11),
+    12: ("Cylinders", ch12),
 }
 
 

--- a/python/features/cylinders.feature
+++ b/python/features/cylinders.feature
@@ -1,0 +1,103 @@
+Feature: Cylinders
+
+Scenario Outline: A ray misses a cylinder
+  Given cyl ← cylinder()
+    And direction ← normalize(<direction>)
+    And r ← ray(<origin>, direction)
+  When xs ← local_intersect(cyl, r)
+  Then xs.count = 0
+
+  Examples:
+    | origin          | direction       |
+    | point(1, 0, 0)  | vector(0, 1, 0) |
+    | point(0, 0, 0)  | vector(0, 1, 0) |
+    | point(0, 0, -5) | vector(1, 1, 1) |
+
+Scenario Outline: A ray strikes a cylinder
+  Given cyl ← cylinder()
+    And direction ← normalize(<direction>)
+    And r ← ray(<origin>, direction)
+  When xs ← local_intersect(cyl, r)
+  Then xs.count = 2
+    And xs[0].t = <t0>
+    And xs[1].t = <t1>
+
+  Examples:
+    | origin            | direction         | t0      | t1      |
+    | point(1, 0, -5)   | vector(0, 0, 1)   | 5       | 5       |
+    | point(0, 0, -5)   | vector(0, 0, 1)   | 4       | 6       |
+    | point(0.5, 0, -5) | vector(0.1, 1, 1) | 6.80798 | 7.08872 |
+
+Scenario Outline: Normal vector on a cylinder
+  Given cyl ← cylinder()
+  When n ← local_normal_at(cyl, <point>)
+  Then n = <normal>
+
+  Examples:
+    | point           | normal           |
+    | point(1, 0, 0)  | vector(1, 0, 0)  |
+    | point(0, 5, -1) | vector(0, 0, -1) |
+    | point(0, -2, 1) | vector(0, 0, 1)  |
+    | point(-1, 1, 0) | vector(-1, 0, 0) |
+
+Scenario: The default minimum and maximum for a cylinder
+  Given cyl ← cylinder()
+  Then cyl.minimum = -infinity
+    And cyl.maximum = infinity
+
+Scenario Outline: Intersecting a constrained cylinder
+  Given cyl ← cylinder()
+    And cyl.minimum ← 1
+    And cyl.maximum ← 2
+    And direction ← normalize(<direction>)
+    And r ← ray(<point>, direction)
+  When xs ← local_intersect(cyl, r)
+  Then xs.count = <count>
+
+  Examples:
+    |   | point             | direction         | count |
+    | 1 | point(0, 1.5, 0)  | vector(0.1, 1, 0) | 0     |
+    | 2 | point(0, 3, -5)   | vector(0, 0, 1)   | 0     |
+    | 3 | point(0, 0, -5)   | vector(0, 0, 1)   | 0     |
+    | 4 | point(0, 2, -5)   | vector(0, 0, 1)   | 0     |
+    | 5 | point(0, 1, -5)   | vector(0, 0, 1)   | 0     |
+    | 6 | point(0, 1.5, -2) | vector(0, 0, 1)   | 2     |
+
+Scenario: The default closed value for a cylinder
+  Given cyl ← cylinder()
+  Then cyl.closed = false
+
+Scenario Outline: Intersecting the caps of a closed cylinder
+  Given cyl ← cylinder()
+    And cyl.minimum ← 1
+    And cyl.maximum ← 2
+    And cyl.closed ← true
+    And direction ← normalize(<direction>)
+    And r ← ray(<point>, direction)
+  When xs ← local_intersect(cyl, r)
+  Then xs.count = <count>
+
+  Examples:
+    |   | point            | direction        | count |
+    | 1 | point(0, 3, 0)   | vector(0, -1, 0) | 2     |
+    | 2 | point(0, 3, -2)  | vector(0, -1, 2) | 2     |
+    | 3 | point(0, 4, -2)  | vector(0, -1, 1) | 2     |
+    | 4 | point(0, 0, -2)  | vector(0, 1, 2)  | 2     |
+    | 5 | point(0, -1, -2) | vector(0, 1, 1)  | 2     |
+
+Scenario Outline: The normal vector on a cylinder's end caps
+  Given cyl ← cylinder()
+    And cyl.minimum ← 1
+    And cyl.maximum ← 2
+    And cyl.closed ← true
+  When n ← local_normal_at(cyl, <point>)
+  Then n = <normal>
+
+  Examples:
+    | point            | normal           |
+    | point(0, 1, 0)   | vector(0, -1, 0) |
+    | point(0.5, 1, 0) | vector(0, -1, 0) |
+    | point(0, 1, 0.5) | vector(0, -1, 0) |
+    | point(0, 2, 0)   | vector(0, 1, 0)  |
+    | point(0.5, 2, 0) | vector(0, 1, 0)  |
+    | point(0, 2, 0.5) | vector(0, 1, 0)  |

--- a/python/features/steps/cylinders.py
+++ b/python/features/steps/cylinders.py
@@ -1,0 +1,63 @@
+import math
+
+from behave import given, then, use_step_matcher, when
+
+from rayz.cylinder import Cylinder
+from rayz.math_parser import parse_math
+from rayz.ray import Ray
+from rayz.tuple import Point, Vector
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+
+
+@given(rf"{_V} ← cylinder\(\)")
+def step_given_cylinder(context, var):
+    setattr(context, var, Cylinder())
+
+
+@given(rf"{_V}\.minimum ← {_A}")
+def step_given_cyl_minimum(context, var, val):
+    getattr(context, var).minimum = parse_math(val)
+
+
+@given(rf"{_V}\.maximum ← {_A}")
+def step_given_cyl_maximum(context, var, val):
+    getattr(context, var).maximum = parse_math(val)
+
+
+@given(rf"{_V}\.closed ← (true|false)")
+def step_given_cyl_closed(context, var, val):
+    getattr(context, var).closed = val == "true"
+
+
+@given(rf"direction ← normalize\(vector\({_A},\s*{_A},\s*{_A}\)\)")
+def step_given_direction_normalize(context, x, y, z):
+    context.direction = Vector(parse_math(x), parse_math(y), parse_math(z)).normalize()
+
+
+@given(rf"r ← ray\(point\({_A},\s*{_A},\s*{_A}\),\s*direction\)")
+def step_given_ray_with_direction_var(context, x, y, z):
+    context.r = Ray(Point(parse_math(x), parse_math(y), parse_math(z)), context.direction)
+
+
+@when(rf"n ← local_normal_at\({_V},\s*point\({_A},\s*{_A},\s*{_A}\)\)")
+def step_when_local_normal_at_cyl(context, var, x, y, z):
+    context.n = getattr(context, var).local_normal_at(Point(parse_math(x), parse_math(y), parse_math(z)))
+
+
+@then(rf"{_V}\.minimum = -infinity")
+def step_then_minimum_neg_inf(context, var):
+    assert getattr(context, var).minimum == -math.inf
+
+
+@then(rf"{_V}\.maximum = infinity")
+def step_then_maximum_inf(context, var):
+    assert getattr(context, var).maximum == math.inf
+
+
+@then(rf"{_V}\.closed = false")
+def step_then_closed_false(context, var):
+    assert getattr(context, var).closed is False

--- a/python/rayz/cylinder.py
+++ b/python/rayz/cylinder.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import math
+
+from rayz.constants import EPSILON
+from rayz.intersection import Intersection
+from rayz.shape import Shape
+from rayz.tuple import Vector
+
+
+class Cylinder(Shape):
+    def __init__(self) -> None:
+        super().__init__()
+        self.minimum = -math.inf
+        self.maximum = math.inf
+        self.closed = False
+
+    def local_intersect(self, ray) -> list:
+        dx, dz = ray.direction.x, ray.direction.z
+        a = dx * dx + dz * dz
+        xs = []
+
+        if abs(a) >= EPSILON:
+            b = 2 * ray.origin.x * dx + 2 * ray.origin.z * dz
+            c = ray.origin.x**2 + ray.origin.z**2 - 1
+            disc = b * b - 4 * a * c
+            if disc >= 0:
+                t0 = (-b - math.sqrt(disc)) / (2 * a)
+                t1 = (-b + math.sqrt(disc)) / (2 * a)
+                if t0 > t1:
+                    t0, t1 = t1, t0
+                y0 = ray.origin.y + t0 * ray.direction.y
+                if self.minimum < y0 < self.maximum:
+                    xs.append(Intersection(t0, self))
+                y1 = ray.origin.y + t1 * ray.direction.y
+                if self.minimum < y1 < self.maximum:
+                    xs.append(Intersection(t1, self))
+
+        self._intersect_caps(ray, xs)
+        return xs
+
+    def local_normal_at(self, point) -> Vector:
+        dist = point.x**2 + point.z**2
+        if dist < 1 and point.y >= self.maximum - EPSILON:
+            return Vector(0, 1, 0)
+        if dist < 1 and point.y <= self.minimum + EPSILON:
+            return Vector(0, -1, 0)
+        return Vector(point.x, 0, point.z)
+
+    def _check_cap(self, ray, t: float) -> bool:
+        x = ray.origin.x + t * ray.direction.x
+        z = ray.origin.z + t * ray.direction.z
+        return x * x + z * z <= 1
+
+    def _intersect_caps(self, ray, xs: list) -> None:
+        if not self.closed or abs(ray.direction.y) < EPSILON:
+            return
+        t = (self.minimum - ray.origin.y) / ray.direction.y
+        if self._check_cap(ray, t):
+            xs.append(Intersection(t, self))
+        t = (self.maximum - ray.origin.y) / ray.direction.y
+        if self._check_cap(ray, t):
+            xs.append(Intersection(t, self))


### PR DESCRIPTION
## Summary

- Add `Cylinder` shape extending `Shape` ABC: discriminant intersection for walls, y-range truncation (min/max), closed end caps via `_intersect_caps`
- Add `cylinders.feature` with 29 scenarios (Scenario Outlines): ray misses, ray strikes, normals, default min/max/closed, constrained cylinder, cap intersections, cap normals
- Fix: strip inline Gherkin table comments (`# corner case`) that behave can't parse
- Add `chapter12.py` example: reflective checkers floor, 4-legged table with cylinders, glass cylinder, metal cylinder, tilted colored cylinder, floor candle

## Test plan

- [x] All 235 BDD scenarios pass (`mise exec -- uv run behave`)
- [x] `ruff check` and `ruff format --check` pass clean
- [x] Chapter 12 example runs and produces `chapter12.ppm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)