### PR TITLE
Add Python Ch 10: Groups and hierarchical transforms

### DIFF
--- a/python/examples/chapter13.py
+++ b/python/examples/chapter13.py
@@ -1,0 +1,114 @@
+"""Chapter 13: Groups — hierarchical scene composition."""
+
+from __future__ import annotations
+
+import math
+import os
+
+from rayz.camera import Camera
+from rayz.color import Color
+from rayz.cylinder import Cylinder
+from rayz.group import Group
+from rayz.pattern import checkers_pattern
+from rayz.plane import Plane
+from rayz.point_light import PointLight
+from rayz.sphere import Sphere
+from rayz.transformations import (
+    rotation_x,
+    scaling,
+    translation,
+    view_transform,
+)
+from rayz.tuple import Point, Vector
+from rayz.world import World
+
+
+def run() -> None:
+    print("\n=== Chapter 13: Groups ===\n")
+
+    world = World()
+    world.light = PointLight(Point(-5, 10, -10), Color(1, 1, 1))
+
+    floor = Plane()
+    floor.material.pattern = checkers_pattern(Color(0.9, 0.9, 0.9), Color(0.1, 0.1, 0.1))
+    floor.material.reflective = 0.1
+    world.objects.append(floor)
+
+    # Tree: trunk (cylinder) + foliage group (spheres)
+    trunk = Cylinder()
+    trunk.minimum = 0
+    trunk.maximum = 1.5
+    trunk.closed = True
+    trunk.material.color = Color(0.4, 0.2, 0.1)
+    trunk.material.specular = 0.1
+
+    foliage = Group()
+    for tx, ty, tz, sx in [(0, 2, 0, 0.8), (-0.5, 1.7, 0, 0.6), (0.5, 1.7, 0.2, 0.6), (0, 2.5, 0, 0.5)]:
+        s = Sphere()
+        s.set_transform(translation(tx, ty, tz) * scaling(sx, sx, sx))
+        s.material.color = Color(0.1, 0.5 + sx * 0.3, 0.1)
+        s.material.specular = 0.3
+        foliage.add_child(s)
+
+    tree = Group()
+    tree.add_child(trunk)
+    tree.add_child(foliage)
+    tree.set_transform(translation(-2, 0, 1))
+    world.objects.append(tree)
+
+    # Snowman: 3 spheres + cylinder nose
+    snowman = Group()
+    for ty, sx in [(0.6, 0.6), (1.5, 0.45), (2.2, 0.3)]:
+        s = Sphere()
+        s.set_transform(translation(0, ty, 0) * scaling(sx, sx, sx))
+        s.material.color = Color(1, 1, 1)
+        s.material.specular = 0.9
+        s.material.shininess = 300
+        snowman.add_child(s)
+
+    nose = Cylinder()
+    nose.minimum = 0
+    nose.maximum = 0.3
+    nose.closed = True
+    nose.set_transform(translation(0, 2.2, 0.3) * rotation_x(math.pi / 2) * scaling(0.08, 1, 0.08))
+    nose.material.color = Color(1, 0.5, 0)
+    nose.material.specular = 0.1
+    snowman.add_child(nose)
+    snowman.set_transform(translation(2, 0, -1))
+    world.objects.append(snowman)
+
+    # Hexagon: 6 colored spheres in a ring
+    hexagon = Group()
+    for i in range(6):
+        angle = i * math.pi / 3
+        s = Sphere()
+        s.set_transform(translation(math.cos(angle), 0.3, math.sin(angle)) * scaling(0.3, 0.3, 0.3))
+        h = i / 6.0
+        s.material.color = Color(
+            (math.sin(h * math.pi * 2) + 1) / 2,
+            (math.sin((h + 0.33) * math.pi * 2) + 1) / 2,
+            (math.sin((h + 0.67) * math.pi * 2) + 1) / 2,
+        )
+        s.material.specular = 0.6
+        s.material.reflective = 0.2
+        hexagon.add_child(s)
+    hexagon.set_transform(translation(0, 0, 3))
+    world.objects.append(hexagon)
+
+    camera = Camera(200, 150, math.pi / 3)
+    camera.transform = view_transform(Point(0, 3, -8), Point(0, 1, 0), Vector(0, 1, 0))
+
+    print("Rendering 200x150 scene with groups (tree, snowman, hexagon)...")
+    canvas = camera.render(world)
+
+    out_path = os.path.join(os.path.dirname(__file__), "chapter13.ppm")
+    print(f"Writing {out_path}...", end="", flush=True)
+    with open(out_path, "w") as f:
+        f.write(canvas.to_ppm())
+    print(" done.")
+    print("Groups scene rendered.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/examples/run.py
+++ b/python/examples/run.py
@@ -21,6 +21,7 @@ from examples.chapter9 import run as ch9
 from examples.chapter10 import run as ch10
 from examples.chapter11 import run as ch11
 from examples.chapter12 import run as ch12
+from examples.chapter13 import run as ch13
 
 CHAPTERS: dict[int, tuple[str, object]] = {
     1: ("Projectile physics", ch1),
@@ -35,6 +36,7 @@ CHAPTERS: dict[int, tuple[str, object]] = {
     10: ("Reflection and Refraction", ch10),
     11: ("Cubes", ch11),
     12: ("Cylinders", ch12),
+    13: ("Groups", ch13),
 }
 
 

--- a/python/features/groups.feature
+++ b/python/features/groups.feature
@@ -1,0 +1,48 @@
+Feature: Groups
+
+Scenario: Creating a new group
+  Given g ← group()
+  Then g.transform = identity_matrix
+    And g is empty
+
+Scenario: Adding a child to a group
+  Given g ← group()
+    And s ← test_shape()
+  When add_child(g, s)
+  Then g is not empty
+    And g includes s
+    And s.parent = g
+
+Scenario: Intersecting a ray with an empty group
+  Given g ← group()
+    And r ← ray(point(0, 0, 0), vector(0, 0, 1))
+  When xs ← local_intersect(g, r)
+  Then xs is empty
+
+Scenario: Intersecting a ray with a nonempty group
+  Given g ← group()
+    And s1 ← sphere()
+    And s2 ← sphere()
+    And set_transform(s2, translation(0, 0, -3))
+    And s3 ← sphere()
+    And set_transform(s3, translation(5, 0, 0))
+    And add_child(g, s1)
+    And add_child(g, s2)
+    And add_child(g, s3)
+  When r ← ray(point(0, 0, -5), vector(0, 0, 1))
+    And xs ← local_intersect(g, r)
+  Then xs.count = 4
+    And xs[0].object = s2
+    And xs[1].object = s2
+    And xs[2].object = s1
+    And xs[3].object = s1
+
+Scenario: Intersecting a transformed group
+  Given g ← group()
+    And set_transform(g, scaling(2, 2, 2))
+    And s ← sphere()
+    And set_transform(s, translation(5, 0, 0))
+    And add_child(g, s)
+  When r ← ray(point(10, 0, -10), vector(0, 0, 1))
+    And xs ← intersect(g, r)
+  Then xs.count = 2

--- a/python/features/shapes.feature
+++ b/python/features/shapes.feature
@@ -53,3 +53,39 @@ Scenario: Computing the normal on a transformed shape
 Scenario: A shape has a parent attribute
   Given s ← test_shape()
   Then s.parent is nothing
+
+Scenario: Converting a point from world to object space
+  Given g1 ← group()
+    And set_transform(g1, rotation_y(π/2))
+    And g2 ← group()
+    And set_transform(g2, scaling(2, 2, 2))
+    And add_child(g1, g2)
+    And s ← sphere()
+    And set_transform(s, translation(5, 0, 0))
+    And add_child(g2, s)
+  When p ← world_to_object(s, point(-2, 0, -10))
+  Then p = point(0, 0, -1)
+
+Scenario: Converting a normal from object to world space
+  Given g1 ← group()
+    And set_transform(g1, rotation_y(π/2))
+    And g2 ← group()
+    And set_transform(g2, scaling(1, 2, 3))
+    And add_child(g1, g2)
+    And s ← sphere()
+    And set_transform(s, translation(5, 0, 0))
+    And add_child(g2, s)
+  When n ← normal_to_world(s, vector(√3/3, √3/3, √3/3))
+  Then n = vector(0.2857, 0.4286, -0.8571)
+
+Scenario: Finding the normal on a child object
+  Given g1 ← group()
+    And set_transform(g1, rotation_y(π/2))
+    And g2 ← group()
+    And set_transform(g2, scaling(1, 2, 3))
+    And add_child(g1, g2)
+    And s ← sphere()
+    And set_transform(s, translation(5, 0, 0))
+    And add_child(g2, s)
+  When n ← normal_at(s, point(1.7321, 1.1547, -5.5774))
+  Then n = vector(0.2857, 0.4286, -0.8571)

--- a/python/features/steps/groups.py
+++ b/python/features/steps/groups.py
@@ -1,0 +1,59 @@
+from behave import given, then, use_step_matcher, when
+
+from rayz.group import Group
+from rayz.math_parser import parse_math
+from rayz.tuple import Point, Vector
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+
+
+@given(rf"{_V} ← group\(\)")
+def step_given_group(context, var):
+    setattr(context, var, Group())
+
+
+@given(rf"add_child\({_V},\s*{_V}\)")
+def step_given_add_child(context, group_var, shape_var):
+    getattr(context, group_var).add_child(getattr(context, shape_var))
+
+
+@when(rf"add_child\({_V},\s*{_V}\)")
+def step_when_add_child(context, group_var, shape_var):
+    getattr(context, group_var).add_child(getattr(context, shape_var))
+
+
+@when(rf"p ← world_to_object\({_V},\s*point\({_A},\s*{_A},\s*{_A}\)\)")
+def step_when_world_to_object(context, shape_var, x, y, z):
+    context.p = getattr(context, shape_var).world_to_object(
+        Point(parse_math(x), parse_math(y), parse_math(z))
+    )
+
+
+@when(rf"n ← normal_to_world\({_V},\s*vector\({_A},\s*{_A},\s*{_A}\)\)")
+def step_when_normal_to_world(context, shape_var, x, y, z):
+    context.n = getattr(context, shape_var).normal_to_world(
+        Vector(parse_math(x), parse_math(y), parse_math(z))
+    )
+
+
+@then(r"g is empty")
+def step_then_group_empty(context):
+    assert context.g.children == []
+
+
+@then(r"g is not empty")
+def step_then_group_not_empty(context):
+    assert context.g.children != []
+
+
+@then(rf"{_V} includes {_V}")
+def step_then_group_includes(context, group_var, shape_var):
+    assert getattr(context, shape_var) in getattr(context, group_var).children
+
+
+@then(rf"{_V}\.parent = {_V}")
+def step_then_parent_eq(context, shape_var, parent_var):
+    assert getattr(context, shape_var).parent is getattr(context, parent_var)

--- a/python/features/steps/rays.py
+++ b/python/features/steps/rays.py
@@ -28,6 +28,18 @@ def step_when_ray_vars(context, var, orig, dirn):
     setattr(context, var, Ray(getattr(context, orig), getattr(context, dirn)))
 
 
+@when(rf"{_V} ← ray\(point\({_A},\s*{_A},\s*{_A}\),\s*vector\({_A},\s*{_A},\s*{_A}\)\)")
+def step_when_ray_inline(context, var, ox, oy, oz, dx, dy, dz):
+    setattr(
+        context,
+        var,
+        Ray(
+            Point(parse_math(ox), parse_math(oy), parse_math(oz)),
+            Vector(parse_math(dx), parse_math(dy), parse_math(dz)),
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Given: named transform matrices (reuse transform factories)
 # ---------------------------------------------------------------------------

--- a/python/rayz/constants.py
+++ b/python/rayz/constants.py
@@ -1,1 +1,1 @@
-EPSILON: float = 1e-5
+EPSILON: float = 1e-4

--- a/python/rayz/group.py
+++ b/python/rayz/group.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from rayz.shape import Shape
+from rayz.tuple import Vector
+
+
+class Group(Shape):
+    def __init__(self) -> None:
+        super().__init__()
+        self.children: list[Shape] = []
+
+    def add_child(self, shape: Shape) -> None:
+        self.children.append(shape)
+        shape.parent = self
+
+    def local_intersect(self, ray) -> list:
+        xs = []
+        for child in self.children:
+            xs.extend(child.intersect(ray))
+        return sorted(xs, key=lambda i: i.t)
+
+    def local_normal_at(self, point) -> Vector:
+        raise RuntimeError("Groups have no surface normals")

--- a/python/rayz/shape.py
+++ b/python/rayz/shape.py
@@ -20,12 +20,24 @@ class Shape(ABC):
         local_ray = ray.transform(self.transform.inverse())
         return self.local_intersect(local_ray)
 
-    def normal_at(self, world_point) -> Vector:
+    def world_to_object(self, point):
+        p = point
+        if self.parent is not None:
+            p = self.parent.world_to_object(p)
+        return self.transform.inverse() * p
+
+    def normal_to_world(self, normal) -> Vector:
         inv = self.transform.inverse()
-        local_point = inv * world_point
+        n = inv.transpose() * normal
+        n = Vector(n.x, n.y, n.z).normalize()
+        if self.parent is not None:
+            n = self.parent.normal_to_world(n)
+        return n
+
+    def normal_at(self, world_point) -> Vector:
+        local_point = self.world_to_object(world_point)
         local_normal = self.local_normal_at(local_point)
-        world_normal = inv.transpose() * local_normal
-        return Vector(world_normal.x, world_normal.y, world_normal.z).normalize()
+        return self.normal_to_world(local_normal)
 
     @abstractmethod
     def local_intersect(self, ray) -> list: ...

--- a/python/rayz/sphere.py
+++ b/python/rayz/sphere.py
@@ -3,24 +3,15 @@ from __future__ import annotations
 import math
 
 from rayz.intersection import Intersection
-from rayz.material import Material
-from rayz.matrix import Matrix
+from rayz.shape import Shape
 from rayz.tuple import Point, Vector
 
 
-class Sphere:
-    def __init__(self) -> None:
-        self.transform = Matrix.identity(4)
-        self.material = Material()
-
-    def set_transform(self, m: Matrix) -> None:
-        self.transform = m
-
-    def intersect(self, ray) -> list[Intersection]:
-        ray2 = ray.transform(self.transform.inverse())
-        sphere_to_ray = ray2.origin - Point(0, 0, 0)
-        a = ray2.direction.dot(ray2.direction)
-        b = 2 * ray2.direction.dot(sphere_to_ray)
+class Sphere(Shape):
+    def local_intersect(self, ray) -> list:
+        sphere_to_ray = ray.origin - Point(0, 0, 0)
+        a = ray.direction.dot(ray.direction)
+        b = 2 * ray.direction.dot(sphere_to_ray)
         c = sphere_to_ray.dot(sphere_to_ray) - 1.0
         disc = b * b - 4 * a * c
         if disc < 0:
@@ -29,15 +20,8 @@ class Sphere:
         t2 = (-b + math.sqrt(disc)) / (2 * a)
         return [Intersection(t1, self), Intersection(t2, self)]
 
-    def normal_at(self, world_point) -> Vector:
-        inv = self.transform.inverse()
-        obj_point = inv * world_point
-        obj_normal = obj_point - Point(0, 0, 0)
-        raw = inv.transpose() * obj_normal
-        return Vector(raw.x, raw.y, raw.z).normalize()
-
-    def __repr__(self) -> str:
-        return f"Sphere(transform={self.transform!r})"
+    def local_normal_at(self, point) -> Vector:
+        return point - Point(0, 0, 0)
 
 
 def glass_sphere() -> Sphere:


### PR DESCRIPTION
## Summary

- Refactor `Sphere` to extend `Shape` ABC via `local_intersect`/`local_normal_at`
- Add `world_to_object()` and `normal_to_world()` to `Shape` with parent-hierarchy traversal
- Update `Shape.normal_at()` to use the parent-aware path
- Add `Group` shape: `add_child` sets `shape.parent`, `local_intersect` aggregates and sorts children
- Widen `EPSILON` from `1e-5` to `1e-4` — book expected values are rounded to 4 decimal places
- Add `groups.feature` (5 scenarios) and 3 new `shapes.feature` scenarios for world/object space transforms
- Add `when r←ray(point,vector)` inline step variant to `rays.py`
- Add `chapter13.py` example: tree (cylinder trunk + sphere foliage), snowman (3 spheres + cylinder nose), hexagon ring, all using nested groups

## Test plan

- [x] All 243 BDD scenarios pass (`mise exec -- uv run behave`)
- [x] `ruff check` and `ruff format --check` pass clean
- [x] Chapter 13 example runs and produces `chapter13.ppm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)