### PR TITLE
Add Python Ch 11: Cones

### DIFF
--- a/python/examples/chapter14.py
+++ b/python/examples/chapter14.py
@@ -1,0 +1,124 @@
+"""Chapter 14: Cones."""
+
+from __future__ import annotations
+
+import math
+import os
+
+from rayz.camera import Camera
+from rayz.color import Color
+from rayz.cone import Cone
+from rayz.pattern import checkers_pattern
+from rayz.plane import Plane
+from rayz.point_light import PointLight
+from rayz.sphere import Sphere
+from rayz.transformations import (
+    rotation_z,
+    scaling,
+    translation,
+    view_transform,
+)
+from rayz.tuple import Point, Vector
+from rayz.world import World
+
+
+def run() -> None:
+    print("\n=== Chapter 14: Cones ===\n")
+
+    world = World()
+    world.light = PointLight(Point(10, 10, -10), Color(1, 1, 1))
+
+    floor = Plane()
+    floor.material.pattern = checkers_pattern(Color(0.5, 0.5, 0.5), Color(0.75, 0.75, 0.75))
+    floor.material.reflective = 0.1
+    world.objects.append(floor)
+
+    # Traffic cone (truncated, closed, orange)
+    traffic = Cone()
+    traffic.minimum = 0
+    traffic.maximum = 2
+    traffic.closed = True
+    traffic.set_transform(translation(-3, 0, -2))
+    traffic.material.color = Color(1, 0.5, 0)
+    traffic.material.ambient = 0.2
+    traffic.material.diffuse = 0.8
+    traffic.material.specular = 0.3
+    world.objects.append(traffic)
+
+    # Glass cone (transparent, closed)
+    glass = Cone()
+    glass.minimum = -1
+    glass.maximum = 1
+    glass.closed = True
+    glass.set_transform(translation(0, 1, 0))
+    glass.material.color = Color(0.8, 0.9, 1.0)
+    glass.material.ambient = 0.0
+    glass.material.diffuse = 0.1
+    glass.material.specular = 1.0
+    glass.material.shininess = 300
+    glass.material.reflective = 0.9
+    glass.material.transparency = 0.9
+    glass.material.refractive_index = 1.5
+    world.objects.append(glass)
+
+    # Metal cone (reflective, inverted)
+    metal = Cone()
+    metal.minimum = 0
+    metal.maximum = 1.5
+    metal.closed = True
+    metal.set_transform(translation(3, 0, -1) * rotation_z(math.pi) * scaling(0.8, 1, 0.8))
+    metal.material.color = Color(0.7, 0.7, 0.7)
+    metal.material.ambient = 0.1
+    metal.material.diffuse = 0.6
+    metal.material.specular = 0.9
+    metal.material.shininess = 200
+    metal.material.reflective = 0.8
+    world.objects.append(metal)
+
+    # Ice cream cone (open, inverted) + scoop
+    ice_cone = Cone()
+    ice_cone.minimum = 0
+    ice_cone.maximum = 2
+    ice_cone.closed = False
+    ice_cone.set_transform(translation(-1.5, 0, 2) * rotation_z(math.pi) * scaling(0.6, 1, 0.6))
+    ice_cone.material.color = Color(0.9, 0.7, 0.4)
+    ice_cone.material.ambient = 0.2
+    ice_cone.material.diffuse = 0.8
+    world.objects.append(ice_cone)
+
+    scoop = Sphere()
+    scoop.set_transform(translation(-1.5, 2, 2) * scaling(0.6, 0.6, 0.6))
+    scoop.material.color = Color(1, 0.7, 0.8)
+    scoop.material.ambient = 0.2
+    scoop.material.diffuse = 0.7
+    world.objects.append(scoop)
+
+    # Hourglass (two cones sharing a tip)
+    for tz_sign, min_y, max_y in [(1, 0, 1), (-1, 0, 1)]:
+        c = Cone()
+        c.minimum = min_y
+        c.maximum = max_y
+        c.closed = False
+        c.set_transform(translation(4, 1, 2) * rotation_z(math.pi * tz_sign) * scaling(0.7, 1, 0.7))
+        c.material.color = Color(0.2, 0.6, 0.8)
+        c.material.diffuse = 0.7
+        c.material.specular = 0.5
+        world.objects.append(c)
+
+    camera = Camera(200, 150, math.pi / 3)
+    camera.transform = view_transform(Point(8, 5, -8), Point(0, 1.5, 0), Vector(0, 1, 0))
+
+    print("Rendering 200x150 scene with cones...")
+    canvas = camera.render(world)
+
+    out_path = os.path.join(os.path.dirname(__file__), "chapter14.ppm")
+    print(f"Writing {out_path}...", end="", flush=True)
+    with open(out_path, "w") as f:
+        f.write(canvas.to_ppm())
+    print(" done.")
+    print("Cones scene rendered.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/examples/run.py
+++ b/python/examples/run.py
@@ -22,6 +22,7 @@ from examples.chapter10 import run as ch10
 from examples.chapter11 import run as ch11
 from examples.chapter12 import run as ch12
 from examples.chapter13 import run as ch13
+from examples.chapter14 import run as ch14
 
 CHAPTERS: dict[int, tuple[str, object]] = {
     1: ("Projectile physics", ch1),
@@ -37,6 +38,7 @@ CHAPTERS: dict[int, tuple[str, object]] = {
     11: ("Cubes", ch11),
     12: ("Cylinders", ch12),
     13: ("Groups", ch13),
+    14: ("Cones", ch14),
 }
 
 

--- a/python/features/cones.feature
+++ b/python/features/cones.feature
@@ -1,0 +1,51 @@
+Feature: Cones
+
+Scenario Outline: Intersecting a cone with a ray
+  Given shape ← cone()
+    And direction ← normalize(<direction>)
+    And r ← ray(<origin>, direction)
+  When xs ← local_intersect(shape, r)
+  Then xs.count = 2
+    And xs[0].t = <t0>
+    And xs[1].t = <t1>
+
+  Examples:
+    | origin          | direction           | t0      | t1       |
+    | point(0, 0, -5) | vector(0, 0, 1)     | 5       |  5       |
+    | point(0, 0, -5) | vector(1, 1, 1)     | 8.66025 |  8.66025 |
+    | point(1, 1, -5) | vector(-0.5, -1, 1) | 4.55006 | 49.44994 |
+
+Scenario: Intersecting a cone with a ray parallel to one of its halves
+  Given shape ← cone()
+    And direction ← normalize(vector(0, 1, 1))
+    And r ← ray(point(0, 0, -1), direction)
+  When xs ← local_intersect(shape, r)
+  Then xs.count = 1
+    And xs[0].t = 0.35355
+
+Scenario Outline: Intersecting a cone's end caps
+  Given shape ← cone()
+    And shape.minimum ← -0.5
+    And shape.maximum ← 0.5
+    And shape.closed ← true
+    And direction ← normalize(<direction>)
+    And r ← ray(<origin>, direction)
+  When xs ← local_intersect(shape, r)
+  Then xs.count = <count>
+
+  Examples:
+    | origin             | direction       | count |
+    | point(0, 0, -5)    | vector(0, 1, 0) | 0     |
+    | point(0, 0, -0.25) | vector(0, 1, 1) | 2     |
+    | point(0, 0, -0.25) | vector(0, 1, 0) | 4     |
+
+Scenario Outline: Computing the normal vector on a cone
+  Given shape ← cone()
+  When n ← local_normal_at(shape, <point>)
+  Then n = <normal>
+
+  Examples:
+    | point             | normal                 |
+    | point(0, 0, 0)    | vector(0, 0, 0)        |
+    | point(1, 1, 1)    | vector(1, -√2, 1)      |
+    | point(-1, -1, 0)  | vector(-1, 1, 0)       |

--- a/python/features/steps/cones.py
+++ b/python/features/steps/cones.py
@@ -1,0 +1,12 @@
+from behave import given, use_step_matcher
+
+from rayz.cone import Cone
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+
+
+@given(rf"{_V} ← cone\(\)")
+def step_given_cone(context, var):
+    setattr(context, var, Cone())

--- a/python/rayz/cone.py
+++ b/python/rayz/cone.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import math
+
+from rayz.constants import EPSILON
+from rayz.intersection import Intersection
+from rayz.shape import Shape
+from rayz.tuple import Vector
+
+
+class Cone(Shape):
+    def __init__(self) -> None:
+        super().__init__()
+        self.minimum = -math.inf
+        self.maximum = math.inf
+        self.closed = False
+
+    def local_intersect(self, ray) -> list:
+        dx, dy, dz = ray.direction.x, ray.direction.y, ray.direction.z
+        ox, oy, oz = ray.origin.x, ray.origin.y, ray.origin.z
+
+        a = dx * dx - dy * dy + dz * dz
+        b = 2 * ox * dx - 2 * oy * dy + 2 * oz * dz
+        c = ox * ox - oy * oy + oz * oz
+
+        xs = []
+
+        if abs(a) < EPSILON:
+            if abs(b) >= EPSILON:
+                t = -c / (2 * b)
+                xs.append(Intersection(t, self))
+        else:
+            disc = b * b - 4 * a * c
+            if disc >= 0:
+                t0 = (-b - math.sqrt(disc)) / (2 * a)
+                t1 = (-b + math.sqrt(disc)) / (2 * a)
+                if t0 > t1:
+                    t0, t1 = t1, t0
+                y0 = oy + t0 * dy
+                if self.minimum < y0 < self.maximum:
+                    xs.append(Intersection(t0, self))
+                y1 = oy + t1 * dy
+                if self.minimum < y1 < self.maximum:
+                    xs.append(Intersection(t1, self))
+
+        self._intersect_caps(ray, xs)
+        return xs
+
+    def local_normal_at(self, point) -> Vector:
+        dist = point.x * point.x + point.z * point.z
+        if dist < point.y * point.y and point.y >= self.maximum - EPSILON:
+            return Vector(0, 1, 0)
+        if dist < point.y * point.y and point.y <= self.minimum + EPSILON:
+            return Vector(0, -1, 0)
+        y = math.sqrt(dist)
+        if point.y > 0:
+            y = -y
+        return Vector(point.x, y, point.z)
+
+    def _check_cap(self, ray, t: float, y: float) -> bool:
+        x = ray.origin.x + t * ray.direction.x
+        z = ray.origin.z + t * ray.direction.z
+        return x * x + z * z <= y * y
+
+    def _intersect_caps(self, ray, xs: list) -> None:
+        if not self.closed or abs(ray.direction.y) < EPSILON:
+            return
+        t = (self.minimum - ray.origin.y) / ray.direction.y
+        if self._check_cap(ray, t, self.minimum):
+            xs.append(Intersection(t, self))
+        t = (self.maximum - ray.origin.y) / ray.direction.y
+        if self._check_cap(ray, t, self.maximum):
+            xs.append(Intersection(t, self))


### PR DESCRIPTION
## Summary

- Implements `rayz/cone.py` — double-napped cone with `local_intersect` (handles ray-parallel-to-half case), `local_normal_at`, truncation (`minimum`/`maximum`), and closed end caps
- Adds `features/cones.feature` (copied from `book_features/`) — 10 scenarios, all passing
- Adds `features/steps/cones.py` — single `cone()` constructor step; all other steps reused from cylinders/spheres/cubes
- Adds `examples/chapter14.py` — demo scene with traffic cone, glass cone, metal cone, ice cream cone, and hourglass
- Wires chapter 14 into `examples/run.py`

## Test plan

- [ ] `mise exec -- uv run behave` → 18 features, 253 scenarios, all pass
- [ ] `mise exec -- uv run python examples/run.py 14` → renders `chapter14.ppm`
- [ ] `mise exec -- uv run ruff check . && mise exec -- uv run ruff format --check .` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)