### PR TITLE
Add Python Ch 12: Triangles, Smooth Triangles, and CSG

### DIFF
--- a/python/examples/chapter15.py
+++ b/python/examples/chapter15.py
@@ -1,0 +1,117 @@
+"""Chapter 15: Triangles."""
+
+from __future__ import annotations
+
+import math
+import os
+
+from rayz.camera import Camera
+from rayz.color import Color
+from rayz.pattern import checkers_pattern
+from rayz.plane import Plane
+from rayz.point_light import PointLight
+from rayz.sphere import Sphere
+from rayz.transformations import rotation_y, scaling, translation, view_transform
+from rayz.triangle import Triangle
+from rayz.tuple import Point, Vector
+from rayz.world import World
+
+
+def run() -> None:
+    print("\n=== Chapter 15: Triangles ===\n")
+
+    world = World()
+    world.light = PointLight(Point(10, 10, -10), Color(1, 1, 1))
+
+    floor = Plane()
+    floor.material.pattern = checkers_pattern(Color(0.5, 0.5, 0.5), Color(0.75, 0.75, 0.75))
+    floor.material.reflective = 0.1
+    world.objects.append(floor)
+
+    # Pyramid: 4 coloured triangular faces
+    h, b = 2.0, 1.5
+    p1, p2 = Point(-b, 0, -b), Point(b, 0, -b)
+    p3, p4 = Point(b, 0, b), Point(-b, 0, b)
+    apex = Point(0, h, 0)
+
+    pyramid_offset = translation(-3, 0, 0)
+    for verts, color in [
+        ((p1, p2, apex), Color(1, 0.3, 0.3)),
+        ((p2, p3, apex), Color(0.3, 1, 0.3)),
+        ((p3, p4, apex), Color(0.3, 0.3, 1)),
+        ((p4, p1, apex), Color(1, 1, 0.3)),
+    ]:
+        face = Triangle(*verts)
+        face.set_transform(pyramid_offset)
+        face.material.color = color
+        face.material.ambient = 0.2
+        face.material.diffuse = 0.7
+        face.material.specular = 0.3
+        world.objects.append(face)
+
+    # Octahedron: 8 triangles
+    s = 1.2
+    top, bot = Point(0, s, 0), Point(0, -s, 0)
+    fr, bk = Point(0, 0, s), Point(0, 0, -s)
+    lft, rgt = Point(-s, 0, 0), Point(s, 0, 0)
+    oct_xf = translation(0, 1.5, 0) * rotation_y(math.pi / 4)
+    oct_faces = [
+        (top, fr, rgt),
+        (top, rgt, bk),
+        (top, bk, lft),
+        (top, lft, fr),
+        (bot, rgt, fr),
+        (bot, bk, rgt),
+        (bot, lft, bk),
+        (bot, fr, lft),
+    ]
+    for i, (a, b_, c) in enumerate(oct_faces):
+        face = Triangle(a, b_, c)
+        face.set_transform(oct_xf)
+        t = i / 8
+        face.material.color = Color(0.2 + t * 0.6, 0.2, 0.8 - t * 0.4)
+        face.material.specular = 0.5
+        world.objects.append(face)
+
+    # Tetrahedron: 4 triangles
+    ts = 1.3
+    tp1, tp2 = Point(0, 0, -ts), Point(-ts, 0, ts)
+    tp3, tapex = Point(ts, 0, ts), Point(0, ts * math.sqrt(3), 0)
+    tet_xf = translation(3, 0, 0)
+    for verts, color in [
+        ((tp1, tp2, tp3), Color(0.9, 0.9, 0.2)),
+        ((tp1, tp3, tapex), Color(0.2, 0.9, 0.9)),
+        ((tp2, tp1, tapex), Color(0.9, 0.2, 0.9)),
+        ((tp3, tp2, tapex), Color(0.9, 0.9, 0.9)),
+    ]:
+        face = Triangle(*verts)
+        face.set_transform(tet_xf)
+        face.material.color = color
+        face.material.ambient = 0.2
+        face.material.diffuse = 0.7
+        face.material.specular = 0.3
+        world.objects.append(face)
+
+    sphere = Sphere()
+    sphere.set_transform(translation(0, 1, -3) * scaling(0.8, 0.8, 0.8))
+    sphere.material.color = Color(0.7, 0.7, 0.7)
+    sphere.material.reflective = 0.3
+    world.objects.append(sphere)
+
+    camera = Camera(200, 150, math.pi / 3)
+    camera.transform = view_transform(Point(8, 5, -8), Point(0, 1, 0), Vector(0, 1, 0))
+
+    print("Rendering 200x150 scene with triangles (pyramid, octahedron, tetrahedron)...")
+    canvas = camera.render(world)
+
+    out_path = os.path.join(os.path.dirname(__file__), "chapter15.ppm")
+    print(f"Writing {out_path}...", end="", flush=True)
+    with open(out_path, "w") as f:
+        f.write(canvas.to_ppm())
+    print(" done.")
+    print("Triangles scene rendered.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/examples/chapter16.py
+++ b/python/examples/chapter16.py
@@ -1,0 +1,125 @@
+"""Chapter 16: Constructive Solid Geometry (CSG)."""
+
+from __future__ import annotations
+
+import math
+import os
+
+from rayz.camera import Camera
+from rayz.color import Color
+from rayz.csg import CSG
+from rayz.cube import Cube
+from rayz.cylinder import Cylinder
+from rayz.pattern import checkers_pattern, gradient_pattern
+from rayz.plane import Plane
+from rayz.point_light import PointLight
+from rayz.sphere import Sphere
+from rayz.transformations import rotation_x, rotation_y, rotation_z, scaling, translation, view_transform
+from rayz.tuple import Point, Vector
+from rayz.world import World
+
+
+def run() -> None:
+    print("\n=== Chapter 16: Constructive Solid Geometry ===\n")
+
+    world = World()
+    world.light = PointLight(Point(-5, 5, -8), Color(1, 1, 1))
+
+    floor = Plane()
+    floor.material.pattern = checkers_pattern(Color(0.8, 0.8, 0.8), Color(0.2, 0.2, 0.2))
+    floor.material.reflective = 0.2
+    floor.material.specular = 0.0
+    world.objects.append(floor)
+
+    back_wall = Plane()
+    back_wall.set_transform(rotation_x(math.pi / 2) * translation(0, 0, 5))
+    back_wall.material.pattern = gradient_pattern(Color(0.3, 0.4, 0.6), Color(0.1, 0.2, 0.3))
+    back_wall.material.specular = 0.0
+    world.objects.append(back_wall)
+
+    # Carved cube: cube minus sphere
+    cube1 = Cube()
+    cube1.material.color = Color(0.9, 0.7, 0.2)
+    carved = CSG("difference", cube1, Sphere())
+    carved.set_transform(translation(-3, 1.5, 0) * rotation_y(math.pi / 6))
+    world.objects.append(carved)
+
+    # Lens: two spheres intersected
+    ls = Sphere()
+    ls.set_transform(translation(-0.5, 0, 0))
+    rs = Sphere()
+    rs.set_transform(translation(0.5, 0, 0))
+    for s in (ls, rs):
+        s.material.transparency = 0.9
+        s.material.refractive_index = 1.5
+        s.material.color = Color(0.8, 0.9, 1.0)
+        s.material.ambient = 0.0
+        s.material.diffuse = 0.1
+        s.material.specular = 0.9
+        s.material.shininess = 300
+    lens = CSG("intersection", ls, rs)
+    lens.set_transform(translation(0, 1, 0) * rotation_y(math.pi / 8))
+    world.objects.append(lens)
+
+    # Hollow sphere: outer minus inner
+    outer = Sphere()
+    outer.material.color = Color(0.8, 0.2, 0.2)
+    inner = Sphere()
+    inner.set_transform(scaling(0.7, 0.7, 0.7))
+    hollow = CSG("difference", outer, inner)
+    hollow.set_transform(translation(3, 1.2, 0))
+    world.objects.append(hollow)
+
+    # Die: cube with pip holes
+    die_cube = Cube()
+    die_cube.material.color = Color(1, 1, 1)
+    die = die_cube
+    for tx, ty, tz in [(0, 0, 1.1), (-0.4, 1.1, -0.4), (0.4, 1.1, -0.4), (-0.4, 1.1, 0.4), (0.4, 1.1, 0.4)]:
+        pip = Sphere()
+        pip.set_transform(translation(tx, ty, tz) * scaling(0.2, 0.2, 0.2))
+        die = CSG("difference", die, pip)
+    die.set_transform(translation(-1.5, 0.55, -2) * rotation_y(math.pi / 5))
+    world.objects.append(die)
+
+    # Rounded cylinder: cylinder union two hemisphere caps
+    cyl = Cylinder()
+    cyl.minimum = -0.5
+    cyl.maximum = 0.5
+    cyl.material.color = Color(0.3, 0.7, 0.3)
+    top_cap = Sphere()
+    top_cap.set_transform(translation(0, 0.5, 0) * scaling(1, 0.5, 1))
+    top_cap.material = cyl.material
+    bot_cap = Sphere()
+    bot_cap.set_transform(translation(0, -0.5, 0) * scaling(1, 0.5, 1))
+    bot_cap.material = cyl.material
+    rounded = CSG("union", CSG("union", cyl, top_cap), bot_cap)
+    rounded.set_transform(translation(1.5, 0.75, -2) * rotation_z(math.pi / 6))
+    world.objects.append(rounded)
+
+    # Wedge-cut sphere
+    ws = Sphere()
+    ws.material.color = Color(0.6, 0.3, 0.8)
+    ws.material.reflective = 0.2
+    wedge = Cube()
+    wedge.set_transform(rotation_y(math.pi / 4) * scaling(2, 2, 0.3))
+    cut = CSG("difference", ws, wedge)
+    cut.set_transform(translation(0, 1, -3) * rotation_y(-math.pi / 8))
+    world.objects.append(cut)
+
+    camera = Camera(200, 150, math.pi / 3)
+    camera.transform = view_transform(Point(0, 2, -8), Point(0, 1, 0), Vector(0, 1, 0))
+
+    print("Rendering 200x150 CSG scene (carved cube, lens, hollow sphere, die, rounded cyl, wedge sphere)...")
+    canvas = camera.render(world)
+
+    out_path = os.path.join(os.path.dirname(__file__), "chapter16.ppm")
+    print(f"Writing {out_path}...", end="", flush=True)
+    with open(out_path, "w") as f:
+        f.write(canvas.to_ppm())
+    print(" done.")
+    print("CSG scene rendered.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/examples/chapter17.py
+++ b/python/examples/chapter17.py
@@ -1,0 +1,112 @@
+"""Chapter 17: Smooth Triangles."""
+
+from __future__ import annotations
+
+import math
+import os
+
+from rayz.camera import Camera
+from rayz.color import Color
+from rayz.pattern import checkers_pattern
+from rayz.plane import Plane
+from rayz.point_light import PointLight
+from rayz.smooth_triangle import SmoothTriangle
+from rayz.transformations import view_transform
+from rayz.triangle import Triangle
+from rayz.tuple import Point, Vector
+from rayz.world import World
+
+
+def run() -> None:
+    print("\n=== Chapter 17: Smooth Triangles ===\n")
+
+    world = World()
+    world.light = PointLight(Point(-10, 10, -10), Color(1, 1, 1))
+
+    floor = Plane()
+    floor.material.pattern = checkers_pattern(Color(0.9, 0.9, 0.9), Color(0.1, 0.1, 0.1))
+    floor.material.reflective = 0.1
+    world.objects.append(floor)
+
+    # Left: flat-shaded pyramid
+    flat_verts = [
+        (Point(-3, 0, -1), Point(-4, 0, 1), Point(-3.5, 2, 0), Color(1, 0, 0)),
+        (Point(-3, 0, -1), Point(-3.5, 2, 0), Point(-2, 0, -1), Color(0, 1, 0)),
+        (Point(-2, 0, -1), Point(-3.5, 2, 0), Point(-4, 0, 1), Color(0, 0, 1)),
+        (Point(-4, 0, 1), Point(-2, 0, -1), Point(-3.5, 2, 0), Color(1, 1, 0)),
+    ]
+    for p1, p2, p3, color in flat_verts:
+        t = Triangle(p1, p2, p3)
+        t.material.color = color
+        t.material.ambient = 0.2
+        t.material.diffuse = 0.8
+        t.material.specular = 0.4
+        t.material.shininess = 50
+        world.objects.append(t)
+
+    # Right: smooth-shaded pyramid (same geometry, vertex normals for smooth shading)
+    apex_n = Vector(0, 1, 0)
+    smooth_verts = [
+        (
+            Point(3, 0, -1),
+            Point(2, 0, 1),
+            Point(2.5, 2, 0),
+            Vector(0.5, 0, -1).normalize(),
+            Vector(-0.5, 0, 1).normalize(),
+            apex_n,
+            Color(1, 0, 0),
+        ),
+        (
+            Point(3, 0, -1),
+            Point(2.5, 2, 0),
+            Point(4, 0, -1),
+            Vector(0.5, 0, -1).normalize(),
+            apex_n,
+            Vector(1, 0, 0).normalize(),
+            Color(0, 1, 0),
+        ),
+        (
+            Point(4, 0, -1),
+            Point(2.5, 2, 0),
+            Point(2, 0, 1),
+            Vector(1, 0, 0).normalize(),
+            apex_n,
+            Vector(-0.5, 0, 1).normalize(),
+            Color(0, 0, 1),
+        ),
+        (
+            Point(2, 0, 1),
+            Point(4, 0, -1),
+            Point(2.5, 2, 0),
+            Vector(-0.5, 0, 1).normalize(),
+            Vector(1, 0, 0).normalize(),
+            apex_n,
+            Color(1, 1, 0),
+        ),
+    ]
+    for p1, p2, p3, n1, n2, n3, color in smooth_verts:
+        st = SmoothTriangle(p1, p2, p3, n1, n2, n3)
+        st.material.color = color
+        st.material.ambient = 0.2
+        st.material.diffuse = 0.8
+        st.material.specular = 0.9
+        st.material.shininess = 200
+        world.objects.append(st)
+
+    camera = Camera(200, 100, math.pi / 3)
+    camera.transform = view_transform(Point(0, 3, -8), Point(0, 1, 0), Vector(0, 1, 0))
+
+    print("Rendering 200x100 scene: flat (left) vs smooth (right) shaded pyramids...")
+    canvas = camera.render(world)
+
+    out_path = os.path.join(os.path.dirname(__file__), "chapter17.ppm")
+    print(f"Writing {out_path}...", end="", flush=True)
+    with open(out_path, "w") as f:
+        f.write(canvas.to_ppm())
+    print(" done.")
+    print("Smooth triangles scene rendered.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/examples/run.py
+++ b/python/examples/run.py
@@ -23,6 +23,9 @@ from examples.chapter11 import run as ch11
 from examples.chapter12 import run as ch12
 from examples.chapter13 import run as ch13
 from examples.chapter14 import run as ch14
+from examples.chapter15 import run as ch15
+from examples.chapter16 import run as ch16
+from examples.chapter17 import run as ch17
 
 CHAPTERS: dict[int, tuple[str, object]] = {
     1: ("Projectile physics", ch1),
@@ -39,6 +42,9 @@ CHAPTERS: dict[int, tuple[str, object]] = {
     12: ("Cylinders", ch12),
     13: ("Groups", ch13),
     14: ("Cones", ch14),
+    15: ("Triangles", ch15),
+    16: ("CSG", ch16),
+    17: ("Smooth Triangles", ch17),
 }
 
 

--- a/python/features/csg.feature
+++ b/python/features/csg.feature
@@ -1,0 +1,79 @@
+Feature: Constructive Solid Geometry (CSG)
+
+Scenario: CSG is created with an operation and two shapes
+  Given s1 ← sphere()
+    And s2 ← cube()
+  When c ← csg("union", s1, s2)
+  Then c.operation = "union"
+    And c.left = s1
+    And c.right = s2
+    And s1.parent = c
+    And s2.parent = c
+
+Scenario Outline: Evaluating the rule for a CSG operation
+  When result ← intersection_allowed("<op>", <lhit>, <inl>, <inr>)
+  Then result = <result>
+
+  Examples:
+  | op           | lhit  | inl   | inr   | result |
+  | union        | true  | true  | true  | false  |
+  | union        | true  | true  | false | true   |
+  | union        | true  | false | true  | false  |
+  | union        | true  | false | false | true   |
+  | union        | false | true  | true  | false  |
+  | union        | false | true  | false | false  |
+  | union        | false | false | true  | true   |
+  | union        | false | false | false | true   |
+  # append after the union examples...
+  | intersection | true  | true  | true  | true   |
+  | intersection | true  | true  | false | false  |
+  | intersection | true  | false | true  | true   |
+  | intersection | true  | false | false | false  |
+  | intersection | false | true  | true  | true   |
+  | intersection | false | true  | false | true   |
+  | intersection | false | false | true  | false  |
+  | intersection | false | false | false | false  |
+  # append after the intersection examples...
+  | difference   | true  | true  | true  | false  |
+  | difference   | true  | true  | false | true   |
+  | difference   | true  | false | true  | false  |
+  | difference   | true  | false | false | true   |
+  | difference   | false | true  | true  | true   |
+  | difference   | false | true  | false | true   |
+  | difference   | false | false | true  | false  |
+  | difference   | false | false | false | false  |
+
+Scenario Outline: Filtering a list of intersections
+  Given s1 ← sphere()
+    And s2 ← cube()
+    And c ← csg("<operation>", s1, s2)
+    And xs ← intersections(1:s1, 2:s2, 3:s1, 4:s2)
+  When result ← filter_intersections(c, xs)
+  Then result.count = 2
+    And result[0] = xs[<x0>]
+    And result[1] = xs[<x1>]
+
+  Examples:
+  | operation    | x0 | x1 |
+  | union        | 0  | 3  |
+  | intersection | 1  | 2  |
+  | difference   | 0  | 1  |
+
+Scenario: A ray misses a CSG object
+  Given c ← csg("union", sphere(), cube())
+    And r ← ray(point(0, 2, -5), vector(0, 0, 1))
+  When xs ← local_intersect(c, r)
+  Then xs is empty
+
+Scenario: A ray hits a CSG object
+  Given s1 ← sphere()
+    And s2 ← sphere()
+    And set_transform(s2, translation(0, 0, 0.5))
+    And c ← csg("union", s1, s2)
+    And r ← ray(point(0, 0, -5), vector(0, 0, 1))
+  When xs ← local_intersect(c, r)
+  Then xs.count = 2
+    And xs[0].t = 4
+    And xs[0].object = s1
+    And xs[1].t = 6.5
+    And xs[1].object = s2

--- a/python/features/smooth-triangles.feature
+++ b/python/features/smooth-triangles.feature
@@ -1,0 +1,36 @@
+Feature: Smooth Triangles
+
+Background:
+  Given p1 ← point(0, 1, 0)
+    And p2 ← point(-1, 0, 0)
+    And p3 ← point(1, 0, 0)
+    And n1 ← vector(0, 1, 0)
+    And n2 ← vector(-1, 0, 0)
+    And n3 ← vector(1, 0, 0)
+  When tri ← smooth_triangle(p1, p2, p3, n1, n2, n3)
+
+Scenario: Constructing a smooth triangle
+  Then tri.p1 = p1
+    And tri.p2 = p2
+    And tri.p3 = p3
+    And tri.n1 = n1
+    And tri.n2 = n2
+    And tri.n3 = n3
+
+Scenario: An intersection with a smooth triangle stores u/v
+  When r ← ray(point(-0.2, 0.3, -2), vector(0, 0, 1))
+    And xs ← local_intersect(tri, r)
+  Then xs[0].u = 0.45
+    And xs[0].v = 0.25
+
+Scenario: A smooth triangle uses u/v to interpolate the normal
+  When i ← intersection_with_uv(1, tri, 0.45, 0.25)
+    And n ← normal_at(tri, point(0, 0, 0), i)
+  Then n = vector(-0.5547, 0.83205, 0)
+
+Scenario: Preparing the normal on a smooth triangle
+  When i ← intersection_with_uv(1, tri, 0.45, 0.25)
+    And r ← ray(point(-0.2, 0.3, -2), vector(0, 0, 1))
+    And xs ← intersections(i)
+    And comps ← prepare_computations(i, r, xs)
+  Then comps.normalv = vector(-0.5547, 0.83205, 0)

--- a/python/features/steps/csg.py
+++ b/python/features/steps/csg.py
@@ -1,0 +1,74 @@
+from behave import given, then, use_step_matcher, when
+
+from rayz.csg import CSG, filter_intersections, intersection_allowed
+from rayz.cube import Cube
+from rayz.sphere import Sphere
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+_SHAPE = r"(sphere\(\)|cube\(\)|[A-Za-z][A-Za-z0-9_]*)"
+
+
+def _resolve_shape(context, spec: str):
+    if spec == "sphere()":
+        return Sphere()
+    if spec == "cube()":
+        return Cube()
+    return getattr(context, spec)
+
+
+@given(rf"{_V} ← csg\(\"([^\"]+)\",\s*{_SHAPE},\s*{_SHAPE}\)")
+def step_given_csg(context, var, op, left, right):
+    setattr(context, var, CSG(op, _resolve_shape(context, left), _resolve_shape(context, right)))
+
+
+@when(rf"{_V} ← csg\(\"([^\"]+)\",\s*{_SHAPE},\s*{_SHAPE}\)")
+def step_when_csg(context, var, op, left, right):
+    setattr(context, var, CSG(op, _resolve_shape(context, left), _resolve_shape(context, right)))
+
+
+@then(rf"{_V}\.operation = \"([^\"]+)\"")
+def step_then_csg_operation(context, var, op):
+    assert getattr(context, var).operation == op
+
+
+@then(rf"{_V}\.left = {_V}")
+def step_then_csg_left(context, csg_var, shape_var):
+    assert getattr(context, csg_var).left is getattr(context, shape_var)
+
+
+@then(rf"{_V}\.right = {_V}")
+def step_then_csg_right(context, csg_var, shape_var):
+    assert getattr(context, csg_var).right is getattr(context, shape_var)
+
+
+@then(rf"{_V}\.parent = {_V}")
+def step_then_shape_parent(context, shape_var, parent_var):
+    assert getattr(context, shape_var).parent is getattr(context, parent_var)
+
+
+@when(r"result ← intersection_allowed\(\"([^\"]+)\",\s*(true|false),\s*(true|false),\s*(true|false)\)")
+def step_when_intersection_allowed(context, op, lhit, inl, inr):
+    context.result = intersection_allowed(op, lhit == "true", inl == "true", inr == "true")
+
+
+@then(r"result = (true|false)")
+def step_then_result_bool(context, val):
+    assert context.result is (val == "true")
+
+
+@when(rf"result ← filter_intersections\({_V},\s*{_V}\)")
+def step_when_filter_intersections(context, csg_var, xs_var):
+    context.result = filter_intersections(getattr(context, csg_var), getattr(context, xs_var))
+
+
+@then(r"result\.count = (\d+)")
+def step_then_result_count(context, n):
+    assert len(context.result) == int(n)
+
+
+@then(rf"result\[(\d+)\] = {_V}\[(\d+)\]")
+def step_then_result_item(context, ri, xs_var, xi):
+    assert context.result[int(ri)] is getattr(context, xs_var)[int(xi)]

--- a/python/features/steps/smooth_triangles.py
+++ b/python/features/steps/smooth_triangles.py
@@ -1,0 +1,85 @@
+import pytest
+from behave import then, use_step_matcher, when
+
+from rayz.intersection import intersection_with_uv, prepare_computations
+from rayz.math_parser import parse_math
+from rayz.smooth_triangle import SmoothTriangle
+from rayz.tuple import Point, Vector
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+
+
+@when(rf"{_V} ← smooth_triangle\({_V},\s*{_V},\s*{_V},\s*{_V},\s*{_V},\s*{_V}\)")
+def step_when_smooth_triangle(context, var, p1, p2, p3, n1, n2, n3):
+    setattr(
+        context,
+        var,
+        SmoothTriangle(
+            getattr(context, p1),
+            getattr(context, p2),
+            getattr(context, p3),
+            getattr(context, n1),
+            getattr(context, n2),
+            getattr(context, n3),
+        ),
+    )
+
+
+@then(rf"{_V}\.n1 = {_V}")
+def step_then_smooth_n1(context, shape, nvar):
+    assert getattr(context, shape).n1 == getattr(context, nvar)
+
+
+@then(rf"{_V}\.n2 = {_V}")
+def step_then_smooth_n2(context, shape, nvar):
+    assert getattr(context, shape).n2 == getattr(context, nvar)
+
+
+@then(rf"{_V}\.n3 = {_V}")
+def step_then_smooth_n3(context, shape, nvar):
+    assert getattr(context, shape).n3 == getattr(context, nvar)
+
+
+@then(rf"xs\[(\d+)\]\.u = {_A}")
+def step_then_xs_u(context, idx, val):
+    assert context.xs[int(idx)].u == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@then(rf"xs\[(\d+)\]\.v = {_A}")
+def step_then_xs_v(context, idx, val):
+    assert context.xs[int(idx)].v == pytest.approx(parse_math(val), abs=1e-5)
+
+
+@when(rf"{_V} ← intersection_with_uv\({_A},\s*{_V},\s*{_A},\s*{_A}\)")
+def step_when_intersection_with_uv(context, var, t, obj_var, u, v):
+    setattr(
+        context,
+        var,
+        intersection_with_uv(parse_math(t), getattr(context, obj_var), parse_math(u), parse_math(v)),
+    )
+
+
+@when(rf"n ← normal_at\({_V},\s*point\({_A},\s*{_A},\s*{_A}\),\s*{_V}\)")
+def step_when_normal_at_with_hit(context, shape_var, x, y, z, hit_var):
+    context.n = getattr(context, shape_var).normal_at(
+        Point(parse_math(x), parse_math(y), parse_math(z)),
+        getattr(context, hit_var),
+    )
+
+
+@when(rf"comps ← prepare_computations\({_V},\s*{_V},\s*{_V}\)")
+def step_when_prepare_computations_3vars(context, i_var, r_var, xs_var):
+    context.comps = prepare_computations(
+        getattr(context, i_var), getattr(context, r_var), getattr(context, xs_var)
+    )
+
+
+@then(rf"comps\.normalv = vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_comps_normalv(context, x, y, z):
+    expected = Vector(parse_math(x), parse_math(y), parse_math(z))
+    assert context.comps.normalv.x == pytest.approx(expected.x, abs=1e-5)
+    assert context.comps.normalv.y == pytest.approx(expected.y, abs=1e-5)
+    assert context.comps.normalv.z == pytest.approx(expected.z, abs=1e-5)

--- a/python/features/steps/triangles.py
+++ b/python/features/steps/triangles.py
@@ -1,0 +1,70 @@
+import pytest
+from behave import given, then, use_step_matcher
+
+from rayz.math_parser import parse_math
+from rayz.triangle import Triangle
+from rayz.tuple import Point, Vector
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+
+
+@given(rf"{_V} ← triangle\({_V},\s*{_V},\s*{_V}\)")
+def step_given_triangle(context, var, p1, p2, p3):
+    setattr(context, var, Triangle(getattr(context, p1), getattr(context, p2), getattr(context, p3)))
+
+
+_P = r"point\(([^\)]+)\)"
+
+
+def _parse_point(spec: str) -> Point:
+    x, y, z = [parse_math(v.strip()) for v in spec.split(",")]
+    return Point(x, y, z)
+
+
+@given(rf"{_V} ← triangle\({_P},\s*{_P},\s*{_P}\)")
+def step_given_triangle_inline(context, var, p1, p2, p3):
+    setattr(context, var, Triangle(_parse_point(p1), _parse_point(p2), _parse_point(p3)))
+
+
+@then(rf"{_V}\.p1 = {_V}")
+def step_then_triangle_p1(context, shape, pt):
+    assert getattr(context, shape).p1 == getattr(context, pt)
+
+
+@then(rf"{_V}\.p2 = {_V}")
+def step_then_triangle_p2(context, shape, pt):
+    assert getattr(context, shape).p2 == getattr(context, pt)
+
+
+@then(rf"{_V}\.p3 = {_V}")
+def step_then_triangle_p3(context, shape, pt):
+    assert getattr(context, shape).p3 == getattr(context, pt)
+
+
+@then(rf"{_V}\.e1 = vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_triangle_e1(context, var, x, y, z):
+    expected = Vector(parse_math(x), parse_math(y), parse_math(z))
+    assert getattr(context, var).e1 == expected
+
+
+@then(rf"{_V}\.e2 = vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_triangle_e2(context, var, x, y, z):
+    expected = Vector(parse_math(x), parse_math(y), parse_math(z))
+    assert getattr(context, var).e2 == expected
+
+
+@then(rf"{_V}\.normal = vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_triangle_normal(context, var, x, y, z):
+    expected = Vector(parse_math(x), parse_math(y), parse_math(z))
+    actual = getattr(context, var).normal
+    assert actual.x == pytest.approx(expected.x, abs=1e-5)
+    assert actual.y == pytest.approx(expected.y, abs=1e-5)
+    assert actual.z == pytest.approx(expected.z, abs=1e-5)
+
+
+@then(rf"{_V} = {_V}\.normal")
+def step_then_var_eq_shape_normal(context, result_var, shape_var):
+    assert getattr(context, result_var) == getattr(context, shape_var).normal

--- a/python/features/triangles.feature
+++ b/python/features/triangles.feature
@@ -1,0 +1,53 @@
+Feature: Triangles
+
+Scenario: Constructing a triangle
+  Given p1 ← point(0, 1, 0)
+    And p2 ← point(-1, 0, 0)
+    And p3 ← point(1, 0, 0)
+    And t ← triangle(p1, p2, p3)
+  Then t.p1 = p1
+    And t.p2 = p2
+    And t.p3 = p3
+    And t.e1 = vector(-1, -1, 0)
+    And t.e2 = vector(1, -1, 0)
+    And t.normal = vector(0, 0, -1)
+
+Scenario: Intersecting a ray parallel to the triangle
+  Given t ← triangle(point(0, 1, 0), point(-1, 0, 0), point(1, 0, 0))
+    And r ← ray(point(0, -1, -2), vector(0, 1, 0))
+  When xs ← local_intersect(t, r)
+  Then xs is empty
+
+Scenario: A ray misses the p1-p3 edge
+  Given t ← triangle(point(0, 1, 0), point(-1, 0, 0), point(1, 0, 0))
+    And r ← ray(point(1, 1, -2), vector(0, 0, 1))
+  When xs ← local_intersect(t, r)
+  Then xs is empty
+
+Scenario: A ray misses the p1-p2 edge
+  Given t ← triangle(point(0, 1, 0), point(-1, 0, 0), point(1, 0, 0))
+    And r ← ray(point(-1, 1, -2), vector(0, 0, 1))
+  When xs ← local_intersect(t, r)
+  Then xs is empty
+
+Scenario: A ray misses the p2-p3 edge
+  Given t ← triangle(point(0, 1, 0), point(-1, 0, 0), point(1, 0, 0))
+    And r ← ray(point(0, -1, -2), vector(0, 0, 1))
+  When xs ← local_intersect(t, r)
+  Then xs is empty
+
+Scenario: A ray strikes a triangle
+  Given t ← triangle(point(0, 1, 0), point(-1, 0, 0), point(1, 0, 0))
+    And r ← ray(point(0, 0.5, -2), vector(0, 0, 1))
+  When xs ← local_intersect(t, r)
+  Then xs.count = 1
+    And xs[0].t = 2
+
+Scenario: Finding the normal on a triangle
+  Given t ← triangle(point(0, 1, 0), point(-1, 0, 0), point(1, 0, 0))
+  When n1 ← local_normal_at(t, point(0, 0.5, 0))
+    And n2 ← local_normal_at(t, point(-0.5, 0.75, 0))
+    And n3 ← local_normal_at(t, point(0.5, 0.25, 0))
+  Then n1 = t.normal
+    And n2 = t.normal
+    And n3 = t.normal

--- a/python/rayz/cone.py
+++ b/python/rayz/cone.py
@@ -46,7 +46,7 @@ class Cone(Shape):
         self._intersect_caps(ray, xs)
         return xs
 
-    def local_normal_at(self, point) -> Vector:
+    def local_normal_at(self, point, hit=None) -> Vector:
         dist = point.x * point.x + point.z * point.z
         if dist < point.y * point.y and point.y >= self.maximum - EPSILON:
             return Vector(0, 1, 0)

--- a/python/rayz/csg.py
+++ b/python/rayz/csg.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from rayz.shape import Shape
+from rayz.tuple import Vector
+
+
+class CSG(Shape):
+    def __init__(self, operation: str, left: Shape, right: Shape) -> None:
+        super().__init__()
+        self.operation = operation
+        self.left = left
+        self.right = right
+        left.parent = self
+        right.parent = self
+
+    def includes(self, shape) -> bool:
+        return _includes(self.left, shape) or _includes(self.right, shape)
+
+    def local_intersect(self, ray) -> list:
+        left_xs = self.left.intersect(ray)
+        right_xs = self.right.intersect(ray)
+        xs = sorted(left_xs + right_xs, key=lambda i: i.t)
+        return filter_intersections(self, xs)
+
+    def local_normal_at(self, point, hit=None) -> Vector:
+        raise RuntimeError("CSG shapes have no surface normal")
+
+
+def _includes(shape, target) -> bool:
+    if hasattr(shape, "includes"):
+        return shape.includes(target)
+    if hasattr(shape, "left"):
+        return _includes(shape.left, target) or _includes(shape.right, target)
+    return shape is target
+
+
+def intersection_allowed(op: str, lhit: bool, inl: bool, inr: bool) -> bool:
+    if op == "union":
+        return (lhit and not inr) or (not lhit and not inl)
+    if op == "intersection":
+        return (lhit and inr) or (not lhit and inl)
+    if op == "difference":
+        return (lhit and not inr) or (not lhit and inl)
+    return False
+
+
+def filter_intersections(csg: CSG, xs: list) -> list:
+    inl, inr = False, False
+    result = []
+    for i in xs:
+        lhit = _includes(csg.left, i.object)
+        if intersection_allowed(csg.operation, lhit, inl, inr):
+            result.append(i)
+        if lhit:
+            inl = not inl
+        else:
+            inr = not inr
+    return result

--- a/python/rayz/cube.py
+++ b/python/rayz/cube.py
@@ -19,7 +19,7 @@ class Cube(Shape):
             return []
         return [Intersection(tmin, self), Intersection(tmax, self)]
 
-    def local_normal_at(self, point) -> Vector:
+    def local_normal_at(self, point, hit=None) -> Vector:
         ax, ay, az = abs(point.x), abs(point.y), abs(point.z)
         maxc = max(ax, ay, az)
         if maxc == ax:

--- a/python/rayz/cylinder.py
+++ b/python/rayz/cylinder.py
@@ -39,7 +39,7 @@ class Cylinder(Shape):
         self._intersect_caps(ray, xs)
         return xs
 
-    def local_normal_at(self, point) -> Vector:
+    def local_normal_at(self, point, hit=None) -> Vector:
         dist = point.x**2 + point.z**2
         if dist < 1 and point.y >= self.maximum - EPSILON:
             return Vector(0, 1, 0)

--- a/python/rayz/group.py
+++ b/python/rayz/group.py
@@ -19,5 +19,5 @@ class Group(Shape):
             xs.extend(child.intersect(ray))
         return sorted(xs, key=lambda i: i.t)
 
-    def local_normal_at(self, point) -> Vector:
+    def local_normal_at(self, point, hit=None) -> Vector:
         raise RuntimeError("Groups have no surface normals")

--- a/python/rayz/intersection.py
+++ b/python/rayz/intersection.py
@@ -4,9 +4,11 @@ from rayz.constants import EPSILON
 
 
 class Intersection:
-    def __init__(self, t: float, obj) -> None:
+    def __init__(self, t: float, obj, u: float | None = None, v: float | None = None) -> None:
         self.t = t
         self.object = obj
+        self.u = u
+        self.v = v
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Intersection):
@@ -15,6 +17,10 @@ class Intersection:
 
     def __repr__(self) -> str:
         return f"Intersection(t={self.t}, object={self.object!r})"
+
+
+def intersection_with_uv(t: float, obj, u: float, v: float) -> Intersection:
+    return Intersection(t, obj, u, v)
 
 
 def intersections(*args: Intersection) -> list[Intersection]:
@@ -39,7 +45,7 @@ def prepare_computations(intersection: Intersection, ray, xs=None):
     obj = intersection.object
     point = ray.position(t)
     eyev = -ray.direction
-    normalv = obj.normal_at(point)
+    normalv = obj.normal_at(point, intersection)
 
     inside = False
     if normalv.dot(eyev) < 0:

--- a/python/rayz/plane.py
+++ b/python/rayz/plane.py
@@ -13,5 +13,5 @@ class Plane(Shape):
         t = -ray.origin.y / ray.direction.y
         return [Intersection(t, self)]
 
-    def local_normal_at(self, point) -> Vector:
+    def local_normal_at(self, point, hit=None) -> Vector:
         return Vector(0, 1, 0)

--- a/python/rayz/shape.py
+++ b/python/rayz/shape.py
@@ -34,16 +34,16 @@ class Shape(ABC):
             n = self.parent.normal_to_world(n)
         return n
 
-    def normal_at(self, world_point) -> Vector:
+    def normal_at(self, world_point, hit=None) -> Vector:
         local_point = self.world_to_object(world_point)
-        local_normal = self.local_normal_at(local_point)
+        local_normal = self.local_normal_at(local_point, hit)
         return self.normal_to_world(local_normal)
 
     @abstractmethod
     def local_intersect(self, ray) -> list: ...
 
     @abstractmethod
-    def local_normal_at(self, point) -> Vector: ...
+    def local_normal_at(self, point, hit=None) -> Vector: ...
 
 
 class TestShape(Shape):
@@ -55,5 +55,5 @@ class TestShape(Shape):
         self.saved_ray = ray
         return []
 
-    def local_normal_at(self, point) -> Vector:
+    def local_normal_at(self, point, hit=None) -> Vector:
         return Vector(point.x, point.y, point.z)

--- a/python/rayz/smooth_triangle.py
+++ b/python/rayz/smooth_triangle.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from rayz.intersection import Intersection
+from rayz.triangle import Triangle
+from rayz.tuple import Vector
+
+
+class SmoothTriangle(Triangle):
+    def __init__(self, p1, p2, p3, n1, n2, n3) -> None:
+        super().__init__(p1, p2, p3)
+        self.n1 = n1
+        self.n2 = n2
+        self.n3 = n3
+
+    def _make_intersections(self, t, u, v) -> list:
+        return [Intersection(t, self, u, v)]
+
+    def local_normal_at(self, point, hit=None) -> Vector:
+        if hit is not None and hit.u is not None and hit.v is not None:
+            return self.n2 * hit.u + self.n3 * hit.v + self.n1 * (1 - hit.u - hit.v)
+        return self.normal

--- a/python/rayz/sphere.py
+++ b/python/rayz/sphere.py
@@ -20,7 +20,7 @@ class Sphere(Shape):
         t2 = (-b + math.sqrt(disc)) / (2 * a)
         return [Intersection(t1, self), Intersection(t2, self)]
 
-    def local_normal_at(self, point) -> Vector:
+    def local_normal_at(self, point, hit=None) -> Vector:
         return point - Point(0, 0, 0)
 
 

--- a/python/rayz/triangle.py
+++ b/python/rayz/triangle.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from rayz.constants import EPSILON
+from rayz.intersection import Intersection
+from rayz.shape import Shape
+from rayz.tuple import Vector
+
+
+class Triangle(Shape):
+    def __init__(self, p1, p2, p3) -> None:
+        super().__init__()
+        self.p1 = p1
+        self.p2 = p2
+        self.p3 = p3
+        d1 = p2 - p1
+        d2 = p3 - p1
+        self.e1 = Vector(d1.x, d1.y, d1.z)
+        self.e2 = Vector(d2.x, d2.y, d2.z)
+        self.normal = self.e2.cross(self.e1).normalize()
+
+    def local_intersect(self, ray) -> list:
+        dir = Vector(ray.direction.x, ray.direction.y, ray.direction.z)
+        dir_cross_e2 = dir.cross(self.e2)
+        det = self.e1.dot(dir_cross_e2)
+        if abs(det) < EPSILON:
+            return []
+        f = 1.0 / det
+        p1_to_origin = ray.origin - self.p1
+        p1o = Vector(p1_to_origin.x, p1_to_origin.y, p1_to_origin.z)
+        u = f * p1o.dot(dir_cross_e2)
+        if u < 0 or u > 1:
+            return []
+        origin_cross_e1 = p1o.cross(self.e1)
+        v = f * dir.dot(origin_cross_e1)
+        if v < 0 or (u + v) > 1:
+            return []
+        t = f * self.e2.dot(origin_cross_e1)
+        return self._make_intersections(t, u, v)
+
+    def _make_intersections(self, t, u, v) -> list:
+        return [Intersection(t, self)]
+
+    def local_normal_at(self, point, hit=None) -> Vector:
+        return self.normal


### PR DESCRIPTION
## Summary

- `rayz/triangle.py` — Triangle primitive with Möller-Trumbore intersection algorithm and flat shading
- `rayz/smooth_triangle.py` — SmoothTriangle extends Triangle, stores u/v in intersections, interpolates normals barycentrically
- `rayz/csg.py` — CSG with union/intersection/difference, `filter_intersections`, and module-level `intersection_allowed` for testing
- `rayz/intersection.py` — Added optional `u`/`v` fields to `Intersection`, `intersection_with_uv()` factory, and passes `hit` to `normal_at` in `prepare_computations`
- `rayz/shape.py` + all shapes — `normal_at` and `local_normal_at` now accept optional `hit` parameter so smooth triangle can interpolate normals
- `features/triangles.feature`, `features/smooth-triangles.feature`, `features/csg.feature` — copied from `book_features/`
- `features/steps/triangles.py`, `features/steps/smooth_triangles.py`, `features/steps/csg.py` — step definitions
- `examples/chapter15.py` — triangles demo (pyramid, octahedron, tetrahedron)
- `examples/chapter16.py` — CSG demo (carved cube, lens, hollow sphere, die, rounded cylinder, wedge sphere)
- `examples/chapter17.py` — smooth vs flat shaded pyramids side by side

## Test plan

- [ ] `mise exec -- uv run behave` → 21 features, 294 scenarios, all pass
- [ ] `mise exec -- uv run python examples/run.py 15 16 17` → renders chapter15/16/17.ppm
- [ ] `mise exec -- uv run ruff check . && mise exec -- uv run ruff format --check .` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)