### PR TITLE
Add Python Ch 13: OBJ File Parser

### DIFF
--- a/python/examples/obj_parser_demo.py
+++ b/python/examples/obj_parser_demo.py
@@ -1,0 +1,89 @@
+"""OBJ Parser Demo: load a Wavefront OBJ model and render it."""
+
+from __future__ import annotations
+
+import os
+
+from rayz.camera import Camera
+from rayz.color import Color
+from rayz.group import Group
+from rayz.obj_parser import obj_to_group, parse_obj_file
+from rayz.pattern import checkers_pattern
+from rayz.plane import Plane
+from rayz.point_light import PointLight
+from rayz.smooth_triangle import SmoothTriangle
+from rayz.transformations import rotation_y, scaling, translation, view_transform
+from rayz.triangle import Triangle
+from rayz.tuple import Point, Vector
+from rayz.world import World
+
+
+def _apply_material(group, material) -> None:
+    for child in group.children:
+        if isinstance(child, Group):
+            _apply_material(child, material)
+        else:
+            child.material = material
+
+
+def _count_triangles(group, count=0) -> int:
+    for child in group.children:
+        if isinstance(child, Group):
+            count = _count_triangles(child, count)
+        elif isinstance(child, (Triangle, SmoothTriangle)):
+            count += 1
+    return count
+
+
+def run() -> None:
+    print("\n=== OBJ Parser Demo ===\n")
+
+    obj_path = os.path.join(os.path.dirname(__file__), "tetrahedron.obj")
+    with open(obj_path) as f:
+        content = f.read()
+
+    parser = parse_obj_file(content)
+    model = obj_to_group(parser)
+    model.set_transform(rotation_y(0.5) * scaling(1.5, 1.5, 1.5))
+
+    from rayz.material import Material
+
+    mat = Material()
+    mat.color = Color(0.8, 0.3, 0.3)
+    mat.diffuse = 0.7
+    mat.specular = 0.3
+    _apply_material(model, mat)
+
+    floor = Plane()
+    floor.set_transform(translation(0, -2, 0))
+    floor.material.pattern = checkers_pattern(Color(0.15, 0.15, 0.15), Color(0.85, 0.85, 0.85))
+    floor.material.ambient = 0.8
+    floor.material.diffuse = 0.2
+    floor.material.specular = 0.0
+    floor.material.reflective = 0.1
+
+    world = World()
+    world.light = PointLight(Point(-5, 5, -5), Color(1, 1, 1))
+    world.objects.append(model)
+    world.objects.append(floor)
+
+    camera = Camera(200, 133, 1.0472)
+    camera.transform = view_transform(Point(0, 3, -6), Point(0, 0, 0), Vector(0, 1, 0))
+
+    n_verts = len(parser.vertices) - 1
+    n_tris = _count_triangles(model)
+    print(f"Loaded model: {n_verts} vertices, {n_tris} triangles")
+    print("Rendering 200x133 scene...")
+    canvas = camera.render(world)
+
+    out_path = os.path.join(os.path.dirname(__file__), "obj_parser_demo.ppm")
+    print(f"Writing {out_path}...", end="", flush=True)
+    with open(out_path, "w") as f:
+        f.write(canvas.to_ppm())
+    print(" done.")
+    print("OBJ parser demo rendered.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/examples/run.py
+++ b/python/examples/run.py
@@ -26,6 +26,7 @@ from examples.chapter14 import run as ch14
 from examples.chapter15 import run as ch15
 from examples.chapter16 import run as ch16
 from examples.chapter17 import run as ch17
+from examples.obj_parser_demo import run as obj_demo
 
 CHAPTERS: dict[int, tuple[str, object]] = {
     1: ("Projectile physics", ch1),
@@ -45,6 +46,7 @@ CHAPTERS: dict[int, tuple[str, object]] = {
     15: ("Triangles", ch15),
     16: ("CSG", ch16),
     17: ("Smooth Triangles", ch17),
+    18: ("OBJ Parser Demo", obj_demo),
 }
 
 

--- a/python/examples/tetrahedron.obj
+++ b/python/examples/tetrahedron.obj
@@ -1,0 +1,15 @@
+# Tetrahedron (triangular pyramid)
+# 4 vertices, 4 triangular faces
+
+v 0 1 0
+v -0.8660 -0.5 0.5
+v 0.8660 -0.5 0.5
+v 0 -0.5 -1
+
+# Base triangle
+f 2 3 4
+
+# Three sides
+f 1 3 2
+f 1 4 3
+f 1 2 4

--- a/python/features/files/triangles.obj
+++ b/python/features/files/triangles.obj
@@ -1,0 +1,9 @@
+v -1 1 0
+v -1 0 0
+v 1 0 0
+v 1 1 0
+
+g FirstGroup
+f 1 2 3
+g SecondGroup
+f 1 3 4

--- a/python/features/obj_file.feature
+++ b/python/features/obj_file.feature
@@ -1,0 +1,134 @@
+Feature: OBJ File Parser
+
+Scenario: Ignoring unrecognized lines
+  Given gibberish ← a file containing:
+    """
+    There was a young lady named Bright
+    who traveled much faster than light.
+    She set out one day
+    in a relative way,
+    and came back the previous night.
+    """
+  When parser ← parse_obj_file(gibberish)
+  Then parser should have ignored 5 lines
+
+Scenario: Vertex records
+  Given file ← a file containing:
+    """
+    v -1 1 0
+    v -1.0000 0.5000 0.0000
+    v 1 0 0
+    v 1 1 0
+    """
+  When parser ← parse_obj_file(file)
+  Then parser.vertices[1] = point(-1, 1, 0)
+    And parser.vertices[2] = point(-1, 0.5, 0)
+    And parser.vertices[3] = point(1, 0, 0)
+    And parser.vertices[4] = point(1, 1, 0)
+
+Scenario: Parsing triangle faces
+  Given file ← a file containing:
+    """
+    v -1 1 0
+    v -1 0 0
+    v 1 0 0
+    v 1 1 0
+
+    f 1 2 3
+    f 1 3 4
+    """
+  When parser ← parse_obj_file(file)
+    And g ← parser.default_group
+    And t1 ← first child of g
+    And t2 ← second child of g
+  Then t1.p1 = parser.vertices[1]
+    And t1.p2 = parser.vertices[2]
+    And t1.p3 = parser.vertices[3]
+    And t2.p1 = parser.vertices[1]
+    And t2.p2 = parser.vertices[3]
+    And t2.p3 = parser.vertices[4]
+
+Scenario: Triangulating polygons
+  Given file ← a file containing:
+    """
+    v -1 1 0
+    v -1 0 0
+    v 1 0 0
+    v 1 1 0
+    v 0 2 0
+
+    f 1 2 3 4 5
+    """
+  When parser ← parse_obj_file(file)
+    And g ← parser.default_group
+    And t1 ← first child of g
+    And t2 ← second child of g
+    And t3 ← third child of g
+  Then t1.p1 = parser.vertices[1]
+    And t1.p2 = parser.vertices[2]
+    And t1.p3 = parser.vertices[3]
+    And t2.p1 = parser.vertices[1]
+    And t2.p2 = parser.vertices[3]
+    And t2.p3 = parser.vertices[4]
+    And t3.p1 = parser.vertices[1]
+    And t3.p2 = parser.vertices[4]
+    And t3.p3 = parser.vertices[5]
+
+Scenario: Triangles in groups
+  Given file ← the file "triangles.obj"
+  When parser ← parse_obj_file(file)
+    And g1 ← "FirstGroup" from parser
+    And g2 ← "SecondGroup" from parser
+    And t1 ← first child of g1
+    And t2 ← first child of g2
+  Then t1.p1 = parser.vertices[1]
+    And t1.p2 = parser.vertices[2]
+    And t1.p3 = parser.vertices[3]
+    And t2.p1 = parser.vertices[1]
+    And t2.p2 = parser.vertices[3]
+    And t2.p3 = parser.vertices[4]
+
+Scenario: Converting an OBJ file to a group
+  Given file ← the file "triangles.obj"
+    And parser ← parse_obj_file(file)
+  When g ← obj_to_group(parser)
+  Then g includes "FirstGroup" from parser
+    And g includes "SecondGroup" from parser
+
+Scenario: Vertex normal records
+  Given file ← a file containing:
+    """
+    vn 0 0 1
+    vn 0.707 0 -0.707
+    vn 1 2 3
+    """
+  When parser ← parse_obj_file(file)
+  Then parser.normals[1] = vector(0, 0, 1)
+    And parser.normals[2] = vector(0.707, 0, -0.707)
+    And parser.normals[3] = vector(1, 2, 3)
+
+Scenario: Faces with normals
+  Given file ← a file containing:
+    """
+    v 0 1 0
+    v -1 0 0
+    v 1 0 0
+
+    vn -1 0 0
+    vn 1 0 0
+    vn 0 1 0
+
+    f 1//3 2//1 3//2
+    f 1/0/3 2/102/1 3/14/2
+    """
+  When parser ← parse_obj_file(file)
+    And g ← parser.default_group
+    And t1 ← first child of g
+    And t2 ← second child of g
+  Then t1.p1 = parser.vertices[1]
+    And t1.p2 = parser.vertices[2]
+    And t1.p3 = parser.vertices[3]
+    And t1.n1 = parser.normals[3]
+    And t1.n2 = parser.normals[1]
+    And t1.n3 = parser.normals[2]
+    And t2 = t1

--- a/python/features/steps/obj_file.py
+++ b/python/features/steps/obj_file.py
@@ -1,0 +1,129 @@
+import os
+
+import pytest
+from behave import given, then, use_step_matcher, when
+
+from rayz.math_parser import parse_math
+from rayz.obj_parser import obj_to_group, parse_obj_file
+from rayz.tuple import Point, Vector
+
+use_step_matcher("re")
+
+_V = r"([A-Za-z][A-Za-z0-9_]*)"
+_A = r"([^\s,)]+)"
+
+_FILES_DIR = os.path.join(os.path.dirname(__file__), "..", "files")
+
+
+@given(rf"{_V} ← a file containing:")
+def step_given_file_containing(context, var):
+    setattr(context, var, context.text)
+
+
+@given(rf"{_V} ← the file \"([^\"]+)\"")
+def step_given_the_file(context, var, filename):
+    path = os.path.join(_FILES_DIR, filename)
+    with open(path) as f:
+        setattr(context, var, f.read())
+
+
+@when(rf"{_V} ← parse_obj_file\({_V}\)")
+def step_when_parse_obj_file(context, parser_var, file_var):
+    setattr(context, parser_var, parse_obj_file(getattr(context, file_var)))
+
+
+@given(rf"{_V} ← parse_obj_file\({_V}\)")
+def step_given_parse_obj_file(context, parser_var, file_var):
+    setattr(context, parser_var, parse_obj_file(getattr(context, file_var)))
+
+
+@then(r"parser should have ignored (\d+) lines")
+def step_then_ignored_lines(context, n):
+    assert context.parser.ignored_lines == int(n)
+
+
+@then(rf"{_V}\.vertices\[(\d+)\] = point\({_A},\s*{_A},\s*{_A}\)")
+def step_then_vertex(context, var, idx, x, y, z):
+    expected = Point(parse_math(x), parse_math(y), parse_math(z))
+    assert getattr(context, var).vertices[int(idx)] == expected
+
+
+@then(rf"{_V}\.normals\[(\d+)\] = vector\({_A},\s*{_A},\s*{_A}\)")
+def step_then_normal(context, var, idx, x, y, z):
+    expected = Vector(parse_math(x), parse_math(y), parse_math(z))
+    actual = getattr(context, var).normals[int(idx)]
+    assert actual.x == pytest.approx(expected.x, abs=1e-4)
+    assert actual.y == pytest.approx(expected.y, abs=1e-4)
+    assert actual.z == pytest.approx(expected.z, abs=1e-4)
+
+
+@when(rf"{_V} ← {_V}\.default_group")
+def step_when_default_group(context, var, parser_var):
+    setattr(context, var, getattr(context, parser_var).default_group)
+
+
+@when(rf"{_V} ← first child of {_V}")
+def step_when_first_child(context, var, group_var):
+    setattr(context, var, getattr(context, group_var).children[0])
+
+
+@when(rf"{_V} ← second child of {_V}")
+def step_when_second_child(context, var, group_var):
+    setattr(context, var, getattr(context, group_var).children[1])
+
+
+@when(rf"{_V} ← third child of {_V}")
+def step_when_third_child(context, var, group_var):
+    setattr(context, var, getattr(context, group_var).children[2])
+
+
+@then(rf"{_V}\.p1 = {_V}\.vertices\[(\d+)\]")
+def step_then_tri_p1_vertex(context, tri_var, parser_var, idx):
+    assert getattr(context, tri_var).p1 is getattr(context, parser_var).vertices[int(idx)]
+
+
+@then(rf"{_V}\.p2 = {_V}\.vertices\[(\d+)\]")
+def step_then_tri_p2_vertex(context, tri_var, parser_var, idx):
+    assert getattr(context, tri_var).p2 is getattr(context, parser_var).vertices[int(idx)]
+
+
+@then(rf"{_V}\.p3 = {_V}\.vertices\[(\d+)\]")
+def step_then_tri_p3_vertex(context, tri_var, parser_var, idx):
+    assert getattr(context, tri_var).p3 is getattr(context, parser_var).vertices[int(idx)]
+
+
+@then(rf"{_V}\.n1 = {_V}\.normals\[(\d+)\]")
+def step_then_tri_n1_normal(context, tri_var, parser_var, idx):
+    assert getattr(context, tri_var).n1 is getattr(context, parser_var).normals[int(idx)]
+
+
+@then(rf"{_V}\.n2 = {_V}\.normals\[(\d+)\]")
+def step_then_tri_n2_normal(context, tri_var, parser_var, idx):
+    assert getattr(context, tri_var).n2 is getattr(context, parser_var).normals[int(idx)]
+
+
+@then(rf"{_V}\.n3 = {_V}\.normals\[(\d+)\]")
+def step_then_tri_n3_normal(context, tri_var, parser_var, idx):
+    assert getattr(context, tri_var).n3 is getattr(context, parser_var).normals[int(idx)]
+
+
+@when(rf"{_V} ← \"([^\"]+)\" from {_V}")
+def step_when_named_group(context, var, name, parser_var):
+    setattr(context, var, getattr(context, parser_var).group(name))
+
+
+@when(rf"{_V} ← obj_to_group\({_V}\)")
+def step_when_obj_to_group(context, var, parser_var):
+    setattr(context, var, obj_to_group(getattr(context, parser_var)))
+
+
+@then(rf"{_V} includes \"([^\"]+)\" from {_V}")
+def step_then_group_includes(context, group_var, name, parser_var):
+    named = getattr(context, parser_var).group(name)
+    group = getattr(context, group_var)
+    assert named in group.children
+
+
+@then(rf"{_V} = {_V}")
+def step_then_vars_equal(context, a, b):
+    assert getattr(context, a) == getattr(context, b)

--- a/python/rayz/obj_parser.py
+++ b/python/rayz/obj_parser.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from rayz.group import Group
+from rayz.smooth_triangle import SmoothTriangle
+from rayz.triangle import Triangle
+from rayz.tuple import Point, Vector
+
+
+class OBJParser:
+    def __init__(self) -> None:
+        self.ignored_lines = 0
+        self.vertices: list = [None]  # 1-based indexing
+        self.normals: list = [None]  # 1-based indexing
+        self.default_group = Group()
+        self.groups: dict[str, Group] = {}
+        self._current_group = self.default_group
+
+    def parse(self, content: str) -> OBJParser:
+        for line in content.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split()
+            cmd = parts[0]
+            if cmd == "v":
+                self.vertices.append(Point(float(parts[1]), float(parts[2]), float(parts[3])))
+            elif cmd == "vn":
+                self.normals.append(Vector(float(parts[1]), float(parts[2]), float(parts[3])))
+            elif cmd == "f":
+                self._parse_face(parts[1:])
+            elif cmd == "g":
+                name = parts[1]
+                grp = Group()
+                self.groups[name] = grp
+                self._current_group = grp
+            else:
+                self.ignored_lines += 1
+        return self
+
+    def group(self, name: str) -> Group:
+        return self.groups[name]
+
+    def _parse_face(self, specs: list[str]) -> None:
+        vdata = []
+        for spec in specs:
+            parts = spec.split("/")
+            vi = int(parts[0])
+            ni = int(parts[2]) if len(parts) > 2 and parts[2] else None
+            vdata.append((vi, ni))
+        for i in range(1, len(vdata) - 1):
+            p1 = self.vertices[vdata[0][0]]
+            p2 = self.vertices[vdata[i][0]]
+            p3 = self.vertices[vdata[i + 1][0]]
+            n0, ni_, ni1 = vdata[0][1], vdata[i][1], vdata[i + 1][1]
+            if n0 and ni_ and ni1:
+                tri = SmoothTriangle(p1, p2, p3, self.normals[n0], self.normals[ni_], self.normals[ni1])
+            else:
+                tri = Triangle(p1, p2, p3)
+            self._current_group.add_child(tri)
+
+
+def parse_obj_file(content: str) -> OBJParser:
+    return OBJParser().parse(content)
+
+
+def obj_to_group(parser: OBJParser) -> Group:
+    g = Group()
+    if parser.default_group.children:
+        g.add_child(parser.default_group)
+    for named in parser.groups.values():
+        g.add_child(named)
+    return g

--- a/python/rayz/smooth_triangle.py
+++ b/python/rayz/smooth_triangle.py
@@ -19,3 +19,15 @@ class SmoothTriangle(Triangle):
         if hit is not None and hit.u is not None and hit.v is not None:
             return self.n2 * hit.u + self.n3 * hit.v + self.n1 * (1 - hit.u - hit.v)
         return self.normal
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SmoothTriangle):
+            return NotImplemented
+        return (
+            self.p1 == other.p1
+            and self.p2 == other.p2
+            and self.p3 == other.p3
+            and self.n1 == other.n1
+            and self.n2 == other.n2
+            and self.n3 == other.n3
+        )

--- a/python/rayz/triangle.py
+++ b/python/rayz/triangle.py
@@ -42,3 +42,8 @@ class Triangle(Shape):
 
     def local_normal_at(self, point, hit=None) -> Vector:
         return self.normal
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Triangle):
+            return NotImplemented
+        return self.p1 == other.p1 and self.p2 == other.p2 and self.p3 == other.p3


### PR DESCRIPTION
## Summary

This is the final PR in the 13-PR Python ray tracer implementation, completing the full port of \"The Ray Tracer Challenge\" book.

- `rayz/obj_parser.py` — Wavefront OBJ parser: vertices (`v`), vertex normals (`vn`), faces (`f`), named groups (`g`), fan triangulation, auto-selects `Triangle` vs `SmoothTriangle` based on normal presence
- `rayz/triangle.py` — Added `__eq__` for structural equality (needed for OBJ face-with-normals test)
- `rayz/smooth_triangle.py` — Added `__eq__` comparing all vertices and normals
- `features/obj_file.feature` — copied from `book_features/`, 8 scenarios
- `features/files/triangles.obj` — test fixture for named-groups scenario
- `features/steps/obj_file.py` — step definitions for OBJ parsing scenarios
- `examples/tetrahedron.obj` — demo model (4 vertices, 4 triangles)
- `examples/obj_parser_demo.py` — renders the tetrahedron OBJ model
- `examples/run.py` — wired as chapter 18

## Test plan

- [ ] `mise exec -- uv run behave` → 22 features, 302 scenarios, all pass
- [ ] `mise exec -- uv run python examples/run.py 18` → renders `obj_parser_demo.ppm`
- [ ] `mise exec -- uv run ruff check . && mise exec -- uv run ruff format --check .` → clean

## Completion

With this PR, all 13 planned PRs are merged:
- Ch 1-2: Tuples, Canvas
- Ch 3-4: Matrices, Transformations
- Ch 5: Ray-sphere intersections
- Ch 6: Lighting, Patterns, World, Camera
- Ch 7: Planes, Reflection/Refraction
- Ch 8-10: Cubes, Cylinders, Groups
- Ch 11: Cones
- Ch 12: Triangles, Smooth Triangles, CSG
- Ch 13: OBJ Parser ← this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)