### PR TITLE
Benchmark Python with fastest variant only (multiprocessing, ~6× faster)

### DIFF
--- a/python/benchmark/run_scene.sh
+++ b/python/benchmark/run_scene.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Run the Python benchmark scene.
-# Called by benchmark/run.sh.
+# Called by benchmark/run.sh with environment variables:
+#   PARALLEL=true|false — enable multiprocessing parallel rendering
 # Args forwarded to scene.py: --scene tiny|small|medium --output /path/to/out.ppm
-# Outputs: one JSON timing line on stdout.
+# Outputs: one JSON timing line on stdout; render progress goes to stderr.
 set -euo pipefail
 
 cd "$(dirname "$0")/.." || exit 1

--- a/python/benchmark/scene.py
+++ b/python/benchmark/scene.py
@@ -103,8 +103,9 @@ def main() -> None:
     camera = Camera(width, height, math.pi / 3)
     camera.transform = view_transform(Point(0, 1.5, -5), Point(0, 1, 0), Vector(0, 1, 0))
 
+    parallel = os.environ.get("PARALLEL", "false").lower() == "true"
     start = time.perf_counter()
-    canvas = camera.render(world)
+    canvas = camera.render_parallel(world) if parallel else camera.render(world)
     with open(args.output, "w") as f:
         f.write(canvas.to_ppm())
     elapsed = time.perf_counter() - start

--- a/python/benchmark/variants.conf
+++ b/python/benchmark/variants.conf
@@ -1,2 +1,21 @@
 # name|description|env_vars
-sequential|Python sequential (single-threaded GIL)|
+#
+# Python benchmark — fastest variant only.
+#
+# Approaches evaluated (production scene sizes, Python 3.14, NumPy 2.x):
+#
+#   1. sequential — single-threaded, GIL-bound
+#      tiny: 5.4s | small: 20.2s | medium: 45.8s
+#      Python's GIL prevents true CPU parallelism via threads.
+#
+#   2. parallel (winner) — multiprocessing via ProcessPoolExecutor
+#      tiny: 1.0s | small: 3.1s | medium: 7.4s  (~6× faster)
+#      Spawns one OS process per CPU core; each has its own GIL.
+#      Row-level work is split across processes; results are
+#      collected and written to the canvas in the main process.
+#
+# Also fixed: Camera.ray_for_pixel() was recomputing the transform
+# inverse on every pixel. Now cached via a transform property setter,
+# matching the Shape.set_transform() pattern.
+#
+parallel|Python multiprocessing (ProcessPoolExecutor, ~6× vs sequential)|PARALLEL=true

--- a/python/rayz/camera.py
+++ b/python/rayz/camera.py
@@ -1,10 +1,34 @@
 from __future__ import annotations
 
 import math
+import os
+from concurrent.futures import ProcessPoolExecutor
 
 from rayz.canvas import Canvas
 from rayz.matrix import Matrix
 from rayz.tuple import Point
+
+
+def _render_chunk(args: tuple) -> list[tuple[int, int, object]]:
+    """Worker: render a slice of rows and return (y, x, color) triples."""
+    camera, world, rows = args
+    from rayz.ray import Ray
+
+    results = []
+    inv = camera._transform_inverse
+    for y in rows:
+        for x in range(camera.hsize):
+            xoffset = (x + 0.5) * camera.pixel_size
+            yoffset = (y + 0.5) * camera.pixel_size
+            world_x = camera._half_width - xoffset
+            world_y = camera._half_height - yoffset
+            pixel_m = inv * Point(world_x, world_y, -1)
+            origin_m = inv * Point(0, 0, 0)
+            direction = (pixel_m - origin_m).normalize()
+            ray = Ray(origin_m, direction)
+            color = world.color_at(ray)
+            results.append((y, x, color))
+    return results
 
 
 class Camera:
@@ -12,8 +36,18 @@ class Camera:
         self.hsize = hsize
         self.vsize = vsize
         self.field_of_view = field_of_view
-        self.transform = Matrix.identity(4)
+        self._transform = Matrix.identity(4)
+        self._transform_inverse = Matrix.identity(4)
         self._calc_pixel_size()
+
+    @property
+    def transform(self) -> Matrix:
+        return self._transform
+
+    @transform.setter
+    def transform(self, m: Matrix) -> None:
+        self._transform = m
+        self._transform_inverse = m.inverse()
 
     def _calc_pixel_size(self) -> None:
         half_view = math.tan(self.field_of_view / 2.0)
@@ -34,7 +68,7 @@ class Camera:
         world_x = self._half_width - xoffset
         world_y = self._half_height - yoffset
 
-        inv = self.transform.inverse()
+        inv = self._transform_inverse
         pixel_m = inv * Point(world_x, world_y, -1)
         origin_m = inv * Point(0, 0, 0)
         direction = (pixel_m - origin_m).normalize()
@@ -47,4 +81,18 @@ class Camera:
                 ray = self.ray_for_pixel(x, y)
                 color = world.color_at(ray)
                 image.write_pixel(col=x, row=self.vsize - 1 - y, color=color)
+        return image
+
+    def render_parallel(self, world, workers: int | None = None) -> Canvas:
+        if workers is None:
+            workers = os.cpu_count() or 1
+        all_rows = list(range(self.vsize))
+        chunk_size = max(1, math.ceil(self.vsize / workers))
+        chunks = [all_rows[i : i + chunk_size] for i in range(0, self.vsize, chunk_size)]
+
+        image = Canvas(self.hsize, self.vsize)
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            for results in executor.map(_render_chunk, [(self, world, chunk) for chunk in chunks]):
+                for y, x, color in results:
+                    image.write_pixel(col=x, row=self.vsize - 1 - y, color=color)
         return image


### PR DESCRIPTION
## Summary

- Replaces the sequential-only Python benchmark with a `multiprocessing` variant using `ProcessPoolExecutor`, which bypasses Python's GIL by spawning real OS processes — one per CPU core
- Fixes `Camera.ray_for_pixel()` which was recomputing the transform matrix inverse on **every pixel** (e.g. 180,000× for a 600×300 scene); now cached via a `transform` property setter, matching the existing `Shape.set_transform()` pattern
- Documents both evaluated approaches and their timing results directly in `variants.conf`, so the benchmark history is self-contained

## Approaches evaluated

| Approach | tiny (200×100) | small (400×200) | medium (600×300) |
|---|---|---|---|
| sequential (GIL-bound) | 5.4s | 20.2s | 45.8s |
| **parallel — ProcessPoolExecutor (winner)** | **1.0s** | **3.1s** | **7.4s** |
| **Speedup** | **5.5×** | **6.5×** | **6.2×** |

Python 3.14, NumPy 2.x. PPM output is pixel-identical between variants (verified with `diff`).

## Why multiprocessing wins

Python threads share one GIL, so only one thread runs Python bytecode at a time — useless for CPU-bound work. `ProcessPoolExecutor` spawns separate interpreter processes, each with its own GIL. The scene world is read-only during rendering, so pickling it into workers is safe and cheap (~5 objects). Row-level chunking keeps the per-task granularity coarse enough that fork overhead is negligible.

## Test plan

- [x] `behave` — 302 scenarios pass, 0 failures
- [x] Both render paths produce identical PPM output
- [x] `./benchmark/run.sh --dev` runs cleanly with the single parallel variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)