### PR TITLE
Add Ractor-based parallel rendering with YJIT support (~3x faster)

### DIFF
--- a/ruby/examples/benchmark.rb
+++ b/ruby/examples/benchmark.rb
@@ -6,7 +6,7 @@ require_relative "../lib/rayz"
 class PerformanceBenchmark
   RESULTS_FILE = "performance_results.json"
 
-  def self.run(label:, iterations: 2)
+  def self.run(label:, iterations: 2, render_mode: true)
     puts "\n" + "=" * 60
     puts "BENCHMARK: #{label}"
     puts "=" * 60
@@ -26,7 +26,7 @@ class PerformanceBenchmark
       iterations.times do |i|
         print "  Iteration #{i + 1}/#{iterations}..."
         time = Benchmark.realtime do
-          camera.render(world)
+          camera.render(world, parallel: render_mode)
         end
         times << time
         puts " #{time.round(2)}s"
@@ -221,6 +221,11 @@ end
 # Run if executed directly
 if __FILE__ == $0
   label = ARGV[0] || "baseline"
-  puts "Running benchmark: #{label}"
-  PerformanceBenchmark.run(label: label)
+  mode = case ARGV[1]
+  when "ractor" then :ractor
+  when "sequential" then false
+  else true
+  end
+  puts "Running benchmark: #{label} (render_mode: #{mode})"
+  PerformanceBenchmark.run(label: label, render_mode: mode)
 end

--- a/ruby/lib/rayz/camera.rb
+++ b/ruby/lib/rayz/camera.rb
@@ -3,20 +3,24 @@ require "etc"
 
 module Rayz
   class Camera
-    attr_accessor :hsize, :vsize, :field_of_view, :transform, :samples_per_pixel, :aperture_size, :focal_distance, :motion_blur
-    attr_reader :pixel_size, :half_width, :half_height
+    attr_accessor :hsize, :vsize, :field_of_view, :samples_per_pixel, :aperture_size, :focal_distance, :motion_blur
+    attr_reader :pixel_size, :half_width, :half_height, :transform
 
     def initialize(hsize:, vsize:, field_of_view:, samples_per_pixel: 1, aperture_size: 0.0, focal_distance: 1.0, motion_blur: false)
       @hsize = hsize
       @vsize = vsize
       @field_of_view = field_of_view
-      @transform = Matrix.identity(4)
-      @samples_per_pixel = samples_per_pixel  # For anti-aliasing (supersampling)
-      @aperture_size = aperture_size  # For focal blur (depth of field)
-      @focal_distance = focal_distance  # Distance to focal plane
-      @motion_blur = motion_blur  # Enable motion blur (rays get random time values)
-
+      @samples_per_pixel = samples_per_pixel
+      @aperture_size = aperture_size
+      @focal_distance = focal_distance
+      @motion_blur = motion_blur
+      self.transform = Matrix.identity(4)
       calculate_pixel_size
+    end
+
+    def transform=(matrix)
+      @transform = matrix
+      @transform_inverse = matrix.inverse
     end
 
     def calculate_pixel_size
@@ -45,9 +49,7 @@ module Rayz
       world_x = @half_width - xoffset
       world_y = @half_height - yoffset
 
-      # Using the camera matrix, transform the canvas point and the origin,
-      # and then compute the ray's direction vector
-      inverse = @transform.inverse
+      inverse = @transform_inverse
 
       # For focal blur, the canvas should be at the focal distance, not at z=-1
       canvas_z = -@focal_distance
@@ -68,10 +70,10 @@ module Rayz
     end
 
     def render(world, parallel: true)
-      if parallel
-        render_parallel(world)
-      else
-        render_sequential(world)
+      case parallel
+      when :ractor then render_ractor(world)
+      when true then render_parallel(world)
+      else render_sequential(world)
       end
     end
 
@@ -149,6 +151,105 @@ module Rayz
       puts "\nDone!"
       puts "Rendering took #{total_time.round(2)} seconds (#{cpu_count} threads)"
       puts "Time per row: #{(time_per_row * 1000).round(2)} ms"
+
+      image
+    end
+
+    def render_ractor(world)
+      image = Canvas.new(width: @hsize, height: @vsize)
+      cpu_count = Etc.nprocessors
+      start_time = Time.now
+
+      puts "Rendering with #{cpu_count} CPU cores (Ractor-based parallelism):"
+      puts "Progress (each dot = completed chunk):"
+
+      # Deep-freeze the scene graph so all Ractors share it without Marshal copying
+      shareable_world = Ractor.make_shareable(world)
+
+      # Copy camera rendering state into a shareable hash (avoids freezing self)
+      cam = Ractor.make_shareable({
+        hsize: @hsize,
+        vsize: @vsize,
+        pixel_size: @pixel_size,
+        half_width: @half_width,
+        half_height: @half_height,
+        transform_inverse: @transform_inverse,
+        samples_per_pixel: @samples_per_pixel,
+        aperture_size: @aperture_size,
+        focal_distance: @focal_distance,
+        motion_blur: @motion_blur
+      })
+
+      chunk_size = [(@vsize.to_f / cpu_count).ceil, 1].max
+
+      ractors = (0...@vsize).step(chunk_size).map do |y_start|
+        y_end = [y_start + chunk_size, @vsize].min
+
+        Ractor.new(y_start, y_end, shareable_world, cam) do |ys, ye, w, c|
+          inv = c[:transform_inverse]
+          width = c[:hsize]
+          ps = c[:pixel_size]
+          hw = c[:half_width]
+          hh = c[:half_height]
+          fd = c[:focal_distance]
+
+          # Precompute camera origin (constant when aperture_size == 0)
+          om = inv * Rayz::Point.new(x: 0.0, y: 0.0, z: 0.0).to_matrix
+          cam_origin = Rayz::Point.new(x: om[0, 0], y: om[1, 0], z: om[2, 0])
+
+          chunk = []
+          (ys...ye).each do |y|
+            (0...width).each do |x|
+              r, g, b = if c[:samples_per_pixel] == 1 && c[:aperture_size] == 0.0 && !c[:motion_blur]
+                xoffset = (x + 0.5) * ps
+                yoffset = (y + 0.5) * ps
+                pm = inv * Rayz::Point.new(x: hw - xoffset, y: hh - yoffset, z: -fd).to_matrix
+                pixel = Rayz::Point.new(x: pm[0, 0], y: pm[1, 0], z: pm[2, 0])
+                direction = (pixel - cam_origin).normalize
+                ray = Rayz::Ray.new(origin: cam_origin, direction: direction, time: 0.0)
+                col = w.color_at(ray)
+                [col.red, col.green, col.blue]
+              else
+                total_r = total_g = total_b = 0.0
+                c[:samples_per_pixel].times do
+                  xo = (x + rand) * ps
+                  yo = (y + rand) * ps
+                  ax = (c[:aperture_size] > 0) ? (rand * 2 - 1) * c[:aperture_size] : 0.0
+                  ay = (c[:aperture_size] > 0) ? (rand * 2 - 1) * c[:aperture_size] : 0.0
+                  t = c[:motion_blur] ? rand : 0.0
+                  pm = inv * Rayz::Point.new(x: hw - xo, y: hh - yo, z: -fd).to_matrix
+                  pixel = Rayz::Point.new(x: pm[0, 0], y: pm[1, 0], z: pm[2, 0])
+                  om2 = inv * Rayz::Point.new(x: ax, y: ay, z: 0.0).to_matrix
+                  orig = Rayz::Point.new(x: om2[0, 0], y: om2[1, 0], z: om2[2, 0])
+                  dir = (pixel - orig).normalize
+                  ray = Rayz::Ray.new(origin: orig, direction: dir, time: t)
+                  col = w.color_at(ray)
+                  total_r += col.red
+                  total_g += col.green
+                  total_b += col.blue
+                end
+                div = c[:samples_per_pixel].to_f
+                [total_r / div, total_g / div, total_b / div]
+              end
+              chunk << [x, y, r, g, b]
+            end
+          end
+          chunk
+        end
+      end
+
+      ractors.each do |ractor|
+        ractor.value.each do |x, y, r, g, b|
+          image.write_pixel(row: @vsize - 1 - y, col: x,
+            color: Rayz::Color.new(red: r, green: g, blue: b))
+        end
+        print "."
+      end
+
+      total_time = Time.now - start_time
+      puts "\nDone!"
+      puts "Rendering took #{total_time.round(2)} seconds (#{cpu_count} Ractors)"
+      puts "Time per row: #{(total_time / @vsize * 1000).round(2)} ms"
 
       image
     end

--- a/ruby/lib/rayz/shape.rb
+++ b/ruby/lib/rayz/shape.rb
@@ -33,7 +33,7 @@ module Rayz
 
       # Transform the ray by the inverse of the shape's transformation
       local_ray = ray.transform(effective_transform_inverse)
-      @saved_ray = local_ray # For test_shape debugging
+      @saved_ray = local_ray unless frozen? # For test_shape debugging
       local_intersect(local_ray)
     end
 

--- a/ruby/mise.toml
+++ b/ruby/mise.toml
@@ -1,2 +1,6 @@
 [tools]
+rust = "1.95.0"
 ruby = "4.0.2"
+
+[env]
+RUBY_CONFIGURE_OPTS = "--enable-yjit"

--- a/ruby/performance_results.json
+++ b/ruby/performance_results.json
@@ -230,5 +230,92 @@
         "pixels_per_second": 2658
       }
     }
+  },
+  "camera-inverse-cache": {
+    "timestamp": "2026-05-09T06:44:51-05:00",
+    "results": {
+      "tiny": {
+        "avg": 0.434,
+        "min": 0.433,
+        "max": 0.435,
+        "stddev": 0.001,
+        "pixels": 5000,
+        "pixels_per_second": 11509
+      },
+      "small": {
+        "avg": 1.543,
+        "min": 1.528,
+        "max": 1.558,
+        "stddev": 0.015,
+        "pixels": 15000,
+        "pixels_per_second": 9721
+      },
+      "medium": {
+        "avg": 8.386,
+        "min": 8.364,
+        "max": 8.408,
+        "stddev": 0.022,
+        "pixels": 30000,
+        "pixels_per_second": 3577
+      }
+    }
+  },
+  "camera-inverse-cache-yjit": {
+    "timestamp": "2026-05-09T06:45:13-05:00",
+    "results": {
+      "tiny": {
+        "avg": 0.255,
+        "min": 0.231,
+        "max": 0.278,
+        "stddev": 0.023,
+        "pixels": 5000,
+        "pixels_per_second": 19641
+      },
+      "small": {
+        "avg": 0.808,
+        "min": 0.806,
+        "max": 0.81,
+        "stddev": 0.002,
+        "pixels": 15000,
+        "pixels_per_second": 18574
+      },
+      "medium": {
+        "avg": 4.386,
+        "min": 4.353,
+        "max": 4.418,
+        "stddev": 0.033,
+        "pixels": 30000,
+        "pixels_per_second": 6841
+      }
+    }
+  },
+  "ractor-yjit": {
+    "timestamp": "2026-05-09T06:49:39-05:00",
+    "results": {
+      "tiny": {
+        "avg": 0.121,
+        "min": 0.064,
+        "max": 0.179,
+        "stddev": 0.058,
+        "pixels": 5000,
+        "pixels_per_second": 41251
+      },
+      "small": {
+        "avg": 0.232,
+        "min": 0.223,
+        "max": 0.242,
+        "stddev": 0.01,
+        "pixels": 15000,
+        "pixels_per_second": 64577
+      },
+      "medium": {
+        "avg": 1.421,
+        "min": 1.421,
+        "max": 1.422,
+        "stddev": 0.001,
+        "pixels": 30000,
+        "pixels_per_second": 21109
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- **Camera transform inverse caching**: Cache `@transform_inverse` in the `transform=` setter (same pattern already used by `Shape`), eliminating redundant O(n³) matrix inversions on every `ray_for_pixel` call
- **Ractor-based parallel renderer**: New `render_ractor` method uses `Ractor.make_shareable` to deep-freeze the scene graph for zero-copy sharing across all CPU cores — bypasses the GVL entirely for true CPU parallelism
- **Frozen shape guard**: Added `unless frozen?` to the `@saved_ray` debug assignment in `Shape#intersect` so frozen shapes work correctly in Ractors
- **Benchmark infrastructure**: `benchmark.rb` now accepts a `render_mode` argument (`ractor`, `sequential`, or default threads); YJIT + Rust 1.95.0 pinned in `mise.toml`

## Benchmark Results

| Variant | Tiny (100×50) | Small (150×100) | Medium (200×150) |
|---|---|---|---|
| Threads, no YJIT | 0.43s | 1.54s | 8.39s |
| Threads + YJIT | 0.25s | 0.81s | 4.39s |
| **Ractors + YJIT** | **0.12s** | **0.23s** | **1.42s** |
| Ractor speedup vs YJIT threads | 2.1× | 3.5× | 3.1× |

The medium scene (reflections + refraction, 30k pixels) is the most representative — **3.1× faster** than the previous best. The key insight is that `Ractor.make_shareable` eliminates the Marshal serialization overhead that made earlier Ractor attempts 2× *slower*.

## Test plan

- [x] All 370 Cucumber scenarios pass (`bundle exec cucumber features/`)
- [x] Smoke-tested Ractor rendering on a live scene before benchmarking
- [x] Verified `@saved_ray` guard doesn't break any existing shape tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)